### PR TITLE
Publish mod descriptor

### DIFF
--- a/.github/workflows/build-npm.yml
+++ b/.github/workflows/build-npm.yml
@@ -162,3 +162,16 @@ jobs:
         uses: juliangruber/read-file-action@v1
         with:
           path: ./module-descriptor.json
+
+      - name: Publish module descriptor
+        if: ${{ env.PUBLISH_MOD_DESCRIPTOR == 'true' && github.ref == 'refs/heads/master' || github.ref  == 'refs/heads/main' }}
+        id: modDescriptorPost
+        uses: fjogeleit/http-request-action@master
+        with:
+          url: ${{ env.FOLIO_MD_REGISTRY }}/_/proxy/modules
+          method: 'POST'
+          contentType: 'application/json; charset=utf-8'
+          customHeaders: '{ "Accept": "application/json; charset=utf-8" }'
+          data: ${{ steps.moduleDescriptor.outputs.content }}
+          username: ${{ secrets.FOLIO_REGISTRY_USERNAME }}
+          password: ${{ secrets.FOLIO_REGISTRY_PASSWORD }}


### PR DESCRIPTION
Now that dependency `mod-lists` descriptor has been deployed, we can enable publishing UI module descriptor