### PR TITLE
Moving query results GET to basic permission

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
           "fqm.entityTypes.collection.get",
           "fqm.entityTypes.item.get",
           "fqm.entityTypes.item.columnValues.get",
+          "fqm.query.async.results.get",
           "lists.collection.get",
           "lists.item.get",
           "lists.item.contents.get",
@@ -129,7 +130,6 @@
         "subPermissions": [
           "module.lists.enabled",
           "fqm.query.async.post",
-          "fqm.query.async.results.get",
           "fqm.query.async.delete",
           "lists.item.refresh",
           "lists.item.refresh.cancel",


### PR DESCRIPTION
- Basic permission group has read access and needs to include this permission to see query results on the List detail page.
- Note that `module.lists.refresh` group inherits from `module.lists.enabled` so it will still have access to this permission.