### PR TITLE
MODFQMMGR-3 Switch to new "entity-types" interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "okapiInterfaces": {
       "lists": "1.0",
       "query": "1.0",
-      "entity_types": "1.0"
+      "entity-types": "1.0"
     },
     "stripesDeps": [
       "@folio/stripes-acq-components"

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "hasSettings": false,
     "okapiInterfaces": {
       "lists": "1.0",
-      "query": "1.0",
+      "fqm-query": "1.0",
       "entity-types": "1.0"
     },
     "stripesDeps": [


### PR DESCRIPTION
This commit switches the entity-types okapi interface from "entity_types" to "entity-types" because it was renamed