### PR TITLE
UILISTS-38 Remove CSS that contained important override

### DIFF
--- a/src/pages/createlist/components/QueryBuilder/QueryBuilder.module.css
+++ b/src/pages/createlist/components/QueryBuilder/QueryBuilder.module.css
@@ -1,3 +1,0 @@
-button[class*="fullWidth"] {
-  width: fit-content !important;
-}

--- a/src/pages/createlist/components/QueryBuilder/QueryBuilder.tsx
+++ b/src/pages/createlist/components/QueryBuilder/QueryBuilder.tsx
@@ -7,8 +7,6 @@ import { t } from '../../../../services';
 import { useRecordsLimit, useMessages } from '../../../../hooks';
 import { HOME_PAGE_URL } from '../../../../constants';
 
-import './QueryBuilder.module.css';
-
 type QueryBuilderProps = {
   selectedType?: string,
   isQueryButtonDisabled?: boolean,


### PR DESCRIPTION
Fixes [UILISTS-38](https://issues.folio.org/browse/UILISTS-38)
In future, CSS should not use !important override as it can break other parts of FOLIO