### PR TITLE
Handle clear filter group properly

### DIFF
--- a/src/pages/lists/ListPage.test.tsx
+++ b/src/pages/lists/ListPage.test.tsx
@@ -63,5 +63,4 @@ describe('ListPage Page', () => {
       expect(screen.queryByText('ui-lists.paneHeader.button.new')).toBeNull();
     });
   });
-
 });

--- a/src/pages/lists/ListPage.tsx
+++ b/src/pages/lists/ListPage.tsx
@@ -32,7 +32,8 @@ export const ListPage: React.FC = () => {
   const { filterConfig, isLoadingConfigData } = useFilterConfig();
   const {
     onChangeFilter,
-    resetAll,
+    onResetAll,
+    onClearGroup,
     filterCount,
     activeFilters,
     appliedFilters
@@ -57,7 +58,7 @@ export const ListPage: React.FC = () => {
               buttonStyle="default"
               disabled={!filterCount}
               id="clickable-reset-all"
-              onClick={resetAll}
+              onClick={onResetAll}
             >
               <Icon icon="times-circle-solid">
                 <FormattedMessage id="stripes-smart-components.resetAll" />
@@ -68,7 +69,7 @@ export const ListPage: React.FC = () => {
             config={filterConfig}
             filters={appliedFilters}
             onChangeFilter={onChangeFilter}
-            onClearFilter={noop}
+            onClearFilter={onClearGroup}
           />
         </Pane>
       }

--- a/src/pages/lists/hooks/useFilters/useFilters.test.ts
+++ b/src/pages/lists/hooks/useFilters/useFilters.test.ts
@@ -1,0 +1,92 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+import { useFilters } from './useFilters';
+
+const filterConfig = [
+  {
+    label: 'Status',
+    name: 'status',
+    cql: 'status',
+    values: ['Active', 'Inactive']
+  }, {
+    label: 'Visibility',
+    name: 'visibility',
+    cql: 'visibility',
+    values: ['Shared', 'Private']
+  }
+];
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('useFilters', () => {
+  it('should initialize state with default values', () => {
+    const { result } = renderHook(() => useFilters(filterConfig));
+
+    expect(result.current.filterCount).toBe(0);
+    expect(result.current.activeFilters).toStrictEqual([]);
+  });
+
+  it('should update filter values', () => {
+    const event = {
+      target: {
+        name: 'status.Active',
+        checked: true
+      }
+    };
+
+    const { result } = renderHook(() => useFilters(filterConfig));
+
+    result.current.onChangeFilter(event);
+
+    expect(result.current.filterCount).toBe(1);
+    expect(result.current.activeFilters).toStrictEqual(['status.Active']);
+  });
+
+  it('should clear filter group', () => {
+    const event = {
+      target: {
+        name: 'status.Active',
+        checked: true
+      }
+    };
+
+    const { result } = renderHook(() => useFilters(filterConfig));
+
+    result.current.onChangeFilter(event);
+    event.target.name = 'visibility.Shared';
+    result.current.onChangeFilter(event);
+
+    expect(result.current.filterCount).toBe(2);
+    expect(result.current.activeFilters).toStrictEqual(['status.Active', 'visibility.Shared']);
+
+    result.current.onClearGroup('status');
+
+    expect(result.current.filterCount).toBe(1);
+    expect(result.current.activeFilters).toStrictEqual(['visibility.Shared']);
+  });
+
+  it('should clear all filters', () => {
+    const event = {
+      target: {
+        name: 'status.Active',
+        checked: true
+      }
+    };
+
+    const { result } = renderHook(() => useFilters(filterConfig));
+
+    result.current.onChangeFilter(event);
+    event.target.name = 'visibility.Shared';
+    result.current.onChangeFilter(event);
+
+    expect(result.current.filterCount).toBe(2);
+    expect(result.current.activeFilters).toStrictEqual(['status.Active', 'visibility.Shared']);
+
+    result.current.onResetAll();
+
+    expect(result.current.filterCount).toBe(0);
+    expect(result.current.activeFilters).toStrictEqual([]);
+  });
+});

--- a/src/pages/lists/hooks/useFilters/useFilters.ts
+++ b/src/pages/lists/hooks/useFilters/useFilters.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { SetStateAction, useState } from 'react';
 import { useLocalStorage, writeStorage } from '@rehooks/local-storage';
 import { APPLIED_FILTERS_KEY } from '../../../../utils/constants';
 import { getFilters } from '../../../../utils';
@@ -16,16 +16,32 @@ export const useFilters = (filterConfig: filterConfigType) => {
 
   const filterCount = activeFilters?.length;
 
+  const saveFilters = (theFilters: SetStateAction<filterConfigType>) => {
+    setFilters(theFilters);
+    writeStorage(APPLIED_FILTERS_KEY, theFilters);
+  };
+
   const onChangeFilter = (e: any) => {
     const aFilters = { ...appliedFilters };
     aFilters[e.target.name] = e.target.checked;
-    setFilters(aFilters);
-    writeStorage(APPLIED_FILTERS_KEY, aFilters);
+    saveFilters(aFilters);
   };
 
-  const resetAll = () => {
-    setFilters(filterConfig);
+  const onResetAll = () => {
+    saveFilters(filterConfig);
   };
 
-  return { onChangeFilter, resetAll, filterCount, activeFilters, appliedFilters };
+  const onClearGroup = (groupName: string) => {
+    const aFilters = { ...appliedFilters };
+
+    for(var name in aFilters) {
+      if (name.startsWith(groupName)) {
+        delete aFilters[name];
+      }
+    }
+
+    saveFilters(aFilters);
+  }
+
+  return { onChangeFilter, onClearGroup, onResetAll, filterCount, activeFilters, appliedFilters };
 };

--- a/src/pages/lists/hooks/useFilters/useFilters.ts
+++ b/src/pages/lists/hooks/useFilters/useFilters.ts
@@ -34,14 +34,14 @@ export const useFilters = (filterConfig: filterConfigType) => {
   const onClearGroup = (groupName: string) => {
     const aFilters = { ...appliedFilters };
 
-    for(var name in aFilters) {
+    for (const name in aFilters) {
       if (name.startsWith(groupName)) {
         delete aFilters[name];
       }
     }
 
     saveFilters(aFilters);
-  }
+  };
 
   return { onChangeFilter, onClearGroup, onResetAll, filterCount, activeFilters, appliedFilters };
 };

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -17,4 +17,4 @@ export const enum USER_PERMS {
   UpdateList = 'lists.item.update',
   DeleteList = 'lists.item.delete',
   ExportList = 'lists.item.export.get'
-};
+}


### PR DESCRIPTION
- Fixes [UILISTS-25](https://issues.folio.org/browse/UILISTS-25)
- Renamed `resetAll` to `onResetAll` to match function naming convention
- Added unit tests
- Lint fixes