### PR TITLE
Permissions Fix

### DIFF
--- a/src/components/ActionMenu/components/ActionsButtonsList/ActionButtonsList.tsx
+++ b/src/components/ActionMenu/components/ActionsButtonsList/ActionButtonsList.tsx
@@ -1,5 +1,5 @@
-import { Button, Icon } from '@folio/stripes/components';
 import React, { FC } from 'react';
+import { Button, Icon } from '@folio/stripes/components';
 import { t, ActionButton } from '../../../../services';
 
 type ActionButtonsListProps = {

--- a/src/pages/editlist/EditListPage.tsx
+++ b/src/pages/editlist/EditListPage.tsx
@@ -12,6 +12,7 @@ import {
   PaneFooter,
   Paneset
 } from '@folio/stripes/components';
+import { useStripes } from '@folio/stripes/core';
 import { useHistory, useParams } from 'react-router-dom';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { HTTPError } from 'ky';
@@ -28,6 +29,7 @@ import { HOME_PAGE_URL } from '../../constants';
 
 export const EditListPage:FC = () => {
   const history = useHistory();
+  const stripes = useStripes();
   const { formatNumber } = useIntl();
   const { id }: {id: string} = useParams();
   const { data: listDetails, isLoading: loadingListDetails } = useListDetails(id);
@@ -160,6 +162,7 @@ export const EditListPage:FC = () => {
             lastMenu={<EditListMenu
               conditions={conditions}
               buttonHandlers={buttonHandlers}
+              stripes={stripes}
             />}
             footer={<PaneFooter
               renderStart={

--- a/src/pages/editlist/components/EditListMenu/EditListMenu.test.tsx
+++ b/src/pages/editlist/components/EditListMenu/EditListMenu.test.tsx
@@ -3,6 +3,10 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { EditListMenu } from './EditListMenu';
 
 describe('EditListMenu', () => {
+  const stripes = {
+    hasPerm: jest.fn().mockReturnValue(true)
+  };
+
   const mockButtonHandlers = {
     'delete': jest.fn(),
     'export': jest.fn(),
@@ -15,7 +19,7 @@ describe('EditListMenu', () => {
   };
 
   it('should render delete and initial export buttons', () => {
-    render(<EditListMenu buttonHandlers={mockButtonHandlers} conditions={mockConditions} />);
+    render(<EditListMenu buttonHandlers={mockButtonHandlers} conditions={mockConditions} stripes={stripes} />);
 
     const deleteButton = screen.getByText('ui-lists.pane.dropdown.delete');
     const exportButton = screen.getByText('ui-lists.pane.dropdown.export');
@@ -25,7 +29,7 @@ describe('EditListMenu', () => {
   });
 
   it('should call delete handler when delete button is clicked', async () => {
-    await render(<EditListMenu buttonHandlers={mockButtonHandlers} conditions={mockConditions} />);
+    await render(<EditListMenu buttonHandlers={mockButtonHandlers} conditions={mockConditions} stripes={stripes} />);
 
     const deleteButton = screen.getByText('ui-lists.pane.dropdown.delete');
     fireEvent.click(deleteButton);
@@ -34,7 +38,7 @@ describe('EditListMenu', () => {
   });
 
   it('should call export handler when export button is clicked', () => {
-    render(<EditListMenu buttonHandlers={mockButtonHandlers} conditions={mockConditions} />);
+    render(<EditListMenu buttonHandlers={mockButtonHandlers} conditions={mockConditions} stripes={stripes} />);
 
     const exportButton = screen.getByText('ui-lists.pane.dropdown.export');
     fireEvent.click(exportButton);
@@ -48,7 +52,7 @@ describe('EditListMenu', () => {
       isExportInProgress: true,
     };
 
-    render(<EditListMenu buttonHandlers={mockButtonHandlers} conditions={conditionsWithExportInProgress} />);
+    render(<EditListMenu buttonHandlers={mockButtonHandlers} conditions={conditionsWithExportInProgress} stripes={stripes} />);
 
     const cancelExportButton = screen.getByText('ui-lists.pane.dropdown.cancel-export');
 
@@ -60,7 +64,7 @@ describe('EditListMenu', () => {
       ...mockConditions,
       isExportInProgress: true,
     };
-    render(<EditListMenu buttonHandlers={mockButtonHandlers} conditions={conditionsWithExportInProgress} />);
+    render(<EditListMenu buttonHandlers={mockButtonHandlers} conditions={conditionsWithExportInProgress} stripes={stripes} />);
 
     const cancelExportButton = screen.getByText('ui-lists.pane.dropdown.cancel-export');
     fireEvent.click(cancelExportButton);

--- a/src/pages/editlist/components/EditListMenu/EditListMenu.test.tsx
+++ b/src/pages/editlist/components/EditListMenu/EditListMenu.test.tsx
@@ -7,6 +7,10 @@ describe('EditListMenu', () => {
     hasPerm: jest.fn().mockReturnValue(true)
   };
 
+  const stripesNoPerm = {
+    hasPerm: jest.fn().mockReturnValue(false)
+  };
+
   const mockButtonHandlers = {
     'delete': jest.fn(),
     'export': jest.fn(),
@@ -70,5 +74,15 @@ describe('EditListMenu', () => {
     fireEvent.click(cancelExportButton);
 
     expect(mockButtonHandlers['cancel-export']).toHaveBeenCalled();
+  });
+
+  it('should not render buttons when user doesn\'t have permission', () => {
+    render(<EditListMenu buttonHandlers={mockButtonHandlers} conditions={mockConditions} stripes={stripesNoPerm} />);
+
+    const deleteButton = screen.queryByText('ui-lists.pane.dropdown.delete');
+    const exportButton = screen.queryByText('ui-lists.pane.dropdown.export');
+
+    expect(deleteButton).toBeNull();
+    expect(exportButton).toBeNull();
   });
 });

--- a/src/pages/editlist/components/EditListMenu/EditListMenu.tsx
+++ b/src/pages/editlist/components/EditListMenu/EditListMenu.tsx
@@ -8,6 +8,7 @@ import {
 } from '../../../../services';
 import { ActionMenu } from '../../../../components';
 import { ICONS } from '../../../../interfaces';
+import { USER_PERMS } from '../../../../utils/constants';
 
 interface ListInformationMenuProps {
   buttonHandlers: {
@@ -15,14 +16,18 @@ interface ListInformationMenuProps {
     'export': () => void,
     'cancel-export': () => void
   },
-  conditions: DisablingConditions
+  conditions: DisablingConditions,
+  stripes: any
 }
 
 export const EditListMenu: React.FC<ListInformationMenuProps> = ({
   conditions,
   buttonHandlers,
+  stripes
 }) => {
   const { isExportInProgress } = conditions;
+
+  const actionButtons:ActionButton[] = [];
 
   const initExportButton = {
     label: 'export',
@@ -39,16 +44,20 @@ export const EditListMenu: React.FC<ListInformationMenuProps> = ({
   };
 
   const exportSlot = isExportInProgress ? cancelExportButton : initExportButton;
+  const deleteSlot = {
+    label: 'delete',
+    icon: ICONS.trash,
+    onClick: buttonHandlers.delete,
+    disabled: isDeleteDisabled(conditions)
+  };
 
-  const actionButtons:ActionButton[] = [
-    {
-      label: 'delete',
-      icon: ICONS.trash,
-      onClick: buttonHandlers.delete,
-      disabled: isDeleteDisabled(conditions)
-    },
-    exportSlot
-  ];
+  if (stripes.hasPerm(USER_PERMS.ExportList)) {
+    actionButtons.push(exportSlot);
+  }
 
-  return <ActionMenu actionButtons={actionButtons} />;
+  if (stripes.hasPerm(USER_PERMS.DeleteList)) {
+    actionButtons.push(deleteSlot);
+  }
+
+  return actionButtons.length ? <ActionMenu actionButtons={actionButtons} /> : <></>;
 };

--- a/src/pages/listInformation/components/ListInformationMenu/ListInformationMenu.tsx
+++ b/src/pages/listInformation/components/ListInformationMenu/ListInformationMenu.tsx
@@ -109,7 +109,6 @@ export const ListInformationMenu: React.FC<ListInformationMenuProps> = ({
   }
 
   return (
-    actionButtons.length ?
     <ActionMenu actionButtons={actionButtons}>
       <Headline size="medium" margin="none" tag="p" faded>
         {t('pane.dropdown.show-columns')}
@@ -122,6 +121,6 @@ export const ListInformationMenu: React.FC<ListInformationMenuProps> = ({
         onChange={onColumnsChange}
         selectedValues={visibleColumns}
       />
-    </ActionMenu> : <></>
+    </ActionMenu>
   );
 };

--- a/src/pages/listInformation/components/ListInformationMenu/ListInformationMenu.tsx
+++ b/src/pages/listInformation/components/ListInformationMenu/ListInformationMenu.tsx
@@ -109,6 +109,7 @@ export const ListInformationMenu: React.FC<ListInformationMenuProps> = ({
   }
 
   return (
+    actionButtons.length ?
     <ActionMenu actionButtons={actionButtons}>
       <Headline size="medium" margin="none" tag="p" faded>
         {t('pane.dropdown.show-columns')}
@@ -121,6 +122,6 @@ export const ListInformationMenu: React.FC<ListInformationMenuProps> = ({
         onChange={onColumnsChange}
         selectedValues={visibleColumns}
       />
-    </ActionMenu>
+    </ActionMenu> : <></>
   );
 };


### PR DESCRIPTION
- Fixes issues raised in [UILISTS-39](https://issues.folio.org/browse/UILISTS-39).
- Previously, permissions were not handled on Edit List page. This has now been corrected.
- Added empty element to prevent menu drop-down from displaying if there are no options to select.
- Added a test case to cover new permission logic.