### PR TITLE
[UILISTS-49] Remove hard dependence on @folio/calendar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .idea
+.vscode
 .env
 *.swp
 *.swo
@@ -9,5 +10,7 @@ npm-debug.log
 yarn.lock
 yarn-error.log
 package-lock.json
+bun.lockb
 junit.xml
 output
+stripes.config.js

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "@babel/plugin-transform-runtime": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-react": "^7.9.0",
-    "@folio/calendar": "^8.0.0",
     "@folio/eslint-config-stripes": "^7.0.0",
     "@folio/stripes": "^9.0.0",
     "@folio/stripes-cli": "^3.0.0",

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,6 +1,3 @@
-declare module '@folio/stripes/components';
-declare module '@folio/stripes/smart-components';
-declare module '@folio/stripes/core';
 declare module '@folio/stripes-acq-components';
 declare module '*.css' {
   const styles: { [className: string]: string };


### PR DESCRIPTION
# [Jira UILISTS-49](https://issues.folio.org/browse/UILISTS-49)

This used to be necessary to load in Stripes typings, however, they are now directly provided by `@folio/stripes` via [stripes-types](https://github.com/folio-org/stripes-types).

- This PR also adds a few items to .gitignore to make local development a bit easier