### PR TITLE
Add missing cancel export permission

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,7 +156,8 @@
           "module.lists.refresh",
           "lists.item.export.download.get",
           "lists.item.export.post",
-          "lists.item.export.get"
+          "lists.item.export.get",
+          "lists.item.export.cancel"
         ]
       },
       {


### PR DESCRIPTION
- Fixes [UILISTS-52](https://issues.folio.org/browse/UILISTS-52)
- Permission `lists.item.export.cancel` was missing from `module.lists.export` group