### PR TITLE
Fix source of lastUpdatedDate and lastUpdatedBy fields

### DIFF
--- a/src/pages/listInformation/components/MetaSectionAccordion/MetaSectionAccordion.tsx
+++ b/src/pages/listInformation/components/MetaSectionAccordion/MetaSectionAccordion.tsx
@@ -31,8 +31,8 @@ export const MetaSectionAccordion: React.FC<MetaSectionAccordionProps> = ({ list
         createdDate={listInfo?.createdDate}
         createdBy={listInfo?.createdByUsername}
         id="userInfoRecordMeta"
-        lastUpdatedDate={listInfo?.successRefresh?.refreshEndDate}
-        lastUpdatedBy={listInfo?.successRefresh?.refreshedByUsername}
+        lastUpdatedDate={listInfo?.updatedDate}
+        lastUpdatedBy={listInfo?.updatedByUsername}
       />
       <KeyValue
         label={<FormattedMessage


### PR DESCRIPTION
Now we take information about last updated date and last updated by from high level of list information instead of success refresh info.