### PR TITLE
[UILISTS-61] Sort record types when creating lists

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "rxjs": "^6.6.3",
     "ts-jest": "^28.0.7",
     "ts-node": "^10.9.1",
-    "typescript": "^4.9.4"
+    "typescript": "^5.2.0"
   },
   "dependencies": {
     "@folio/stripes-acq-components": "~5.0.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "rxjs": "^6.6.3",
     "ts-jest": "^28.0.7",
     "ts-node": "^10.9.1",
-    "typescript": "^5.2.0"
+    "typescript": "^4.9.4"
   },
   "dependencies": {
     "@folio/stripes-acq-components": "~5.0.0",

--- a/src/pages/createlist/helpers.ts
+++ b/src/pages/createlist/helpers.ts
@@ -1,18 +1,23 @@
-import { EntityTypeSelectOption, EntityTypeOption } from '../../interfaces';
+import { EntityTypeOption, EntityTypeSelectOption } from '../../interfaces';
 import { t } from '../../services';
 
-export const computeRecordTypeOptions = (entityTypes: EntityTypeOption[], selected = ''): EntityTypeSelectOption[] => {
+export const computeRecordTypeOptions = (
+  entityTypes: EntityTypeOption[],
+  selected = '',
+): EntityTypeSelectOption[] => {
   const defaultPlaceholder = {
     label: t('create-list.choose-record-type'),
     selected: false,
     value: '',
   };
 
-  let options = entityTypes.map(({ id, label }) => ({
-    label,
-    value: id,
-    selected: id === selected
-  })) as EntityTypeSelectOption[];
+  let options = entityTypes
+    .toSorted((a, b) => a.label.localeCompare(b.label))
+    .map(({ id, label }) => ({
+      label,
+      value: id,
+      selected: id === selected,
+    })) as EntityTypeSelectOption[];
 
   if (!selected) {
     options = [defaultPlaceholder, ...options];

--- a/src/pages/createlist/helpers.ts
+++ b/src/pages/createlist/helpers.ts
@@ -12,12 +12,15 @@ export const computeRecordTypeOptions = (
   };
 
   let options = entityTypes
-    .toSorted((a, b) => a.label.localeCompare(b.label))
     .map(({ id, label }) => ({
       label,
       value: id,
       selected: id === selected,
     })) as EntityTypeSelectOption[];
+
+  // EntityTypeSelectOption has label as ReactNode, but we just created it above
+  // where all these labels are string only, so we can safely coerce to string
+  options.sort((a, b) => (a.label as string).localeCompare(b.label as string));
 
   if (!selected) {
     options = [defaultPlaceholder, ...options];

--- a/src/services/translation/tests/translation.test.tsx
+++ b/src/services/translation/tests/translation.test.tsx
@@ -1,9 +1,10 @@
-import { render, screen } from '@testing-library/react';
 import { describe } from '@jest/globals';
-import { t, UI_LISTS_NAMESPACE } from '../translation';
+import { render, screen } from '@testing-library/react';
+import { createIntl } from 'react-intl';
+import { UI_LISTS_NAMESPACE, t, tString } from '../translation';
 
 describe('Wrapper for translation', () => {
-  it('is expected to return sting with prefix', () => {
+  it('is expected to return (JSX) key with prefix', () => {
     const translationKey = 'button-text';
     const translationKeyWithPrefix = `${UI_LISTS_NAMESPACE}.${translationKey}`;
     render(<button type="button">{t('button-text')}</button>);
@@ -14,7 +15,7 @@ describe('Wrapper for translation', () => {
 
     expect(button).toBeInTheDocument();
   });
-  it('is expected to return key with prefix and values', () => {
+  it('is expected to return (JSX) key with prefix and values', () => {
     const translationKey = `button-text-${JSON.stringify({ count: 1 })}`;
     const translationKeyWithPrefixAndValues = `${UI_LISTS_NAMESPACE}.${translationKey}`;
     render(<button type="button">{t('button-text', { count: 1 })}</button>);
@@ -24,5 +25,27 @@ describe('Wrapper for translation', () => {
     });
 
     expect(button).toBeInTheDocument();
+  });
+  it('is expected to return (string) key with prefix', () => {
+    const translationKey = 'test';
+    const intl = createIntl({
+      locale: 'en',
+      messages: {
+        'ui-lists.test': 'translated value',
+      },
+    });
+
+    expect(tString(intl, translationKey)).toEqual('translated value');
+  });
+  it('is expected to return (string) key with prefix and values', () => {
+    const translationKey = 'test';
+    const intl = createIntl({
+      locale: 'en',
+      messages: {
+        'ui-lists.test': 'count={count}',
+      },
+    });
+
+    expect(tString(intl, translationKey, { count: 1 })).toEqual('count=1');
   });
 });

--- a/src/services/translation/translation.tsx
+++ b/src/services/translation/translation.tsx
@@ -1,14 +1,26 @@
 import React from 'react';
-import { FormattedMessage, FormattedNumber, FormattedTime, FormattedDate } from 'react-intl';
+import { FormattedMessage, FormattedNumber, FormattedTime, FormattedDate, IntlShape } from 'react-intl';
 
 export const UI_LISTS_NAMESPACE = 'ui-lists';
 
+/** Translate a given translation ID, returning a JSX element */
 export const t = (id: string, values?: {
     [key: string]: string | number
 }) => {
   const idWithPrefix = `${UI_LISTS_NAMESPACE}.${id}`;
 
   return <FormattedMessage id={idWithPrefix} values={values} />;
+};
+
+/**
+ * Translate a given translation ID, returning a string
+ *
+ * @param intl should come from useIntl() in the calling code
+ */
+export const tString = (intl: IntlShape, id: string, values?: Record<string, string|number>) => {
+  const idWithPrefix = `${UI_LISTS_NAMESPACE}.${id}`;
+
+  return intl.formatMessage({ id: idWithPrefix }, values);
 };
 
 export const formatNumber = (number: (string | number) = 0) => {

--- a/translations/ui-lists/en.json
+++ b/translations/ui-lists/en.json
@@ -58,7 +58,7 @@
 
   "create-list.aside.set-criteria": "Set criteria",
   "create-list.aside.set-criteria-to-build": "Set criteria to build query",
-  "create-list.aside.record-types": "Record types",
+  "create-list.aside.record-types": "Record type",
   "create-list.aside.build-query": "Build query",
 
   "create-list.main.collapse-all": "Collapse all",


### PR DESCRIPTION
# [Jira UILISTS-61](https://issues.folio.org/browse/UILISTS-61)

This adds a quick fix to sort record types from the backend.

## ✨ bonus ✨ 
- added some additional translation infrastructure for [MODFQMMGR-78](https://issues.folio.org/browse/MODFQMMGR-78) (continues this with actual localization)
- fixed a typo (label for the record type dropdown should be "Record type", not "Record types"