### PR TITLE
[UILISTS-49] Remove dependence on calendar typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "@babel/plugin-transform-runtime": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-react": "^7.9.0",
-    "@folio/calendar": "^8.0.0",
     "@folio/eslint-config-stripes": "^7.0.0",
     "@folio/stripes": "^9.0.0",
     "@folio/stripes-cli": "^3.0.0",

--- a/src/components/ActionMenu/ActionMenu.tsx
+++ b/src/components/ActionMenu/ActionMenu.tsx
@@ -35,6 +35,7 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({
     >
       <DropdownMenu
         aria-label="available permissions"
+        onToggle={handleToggle}
       >
         <div className={children ? css.actionMenuGroup : ''}>
           <ActionButtonsList buttons={actionButtons} handleClick={handleClick} />

--- a/src/components/ListsTable/ListsTable.tsx
+++ b/src/components/ListsTable/ListsTable.tsx
@@ -80,10 +80,9 @@ export const ListsTable: FC<ListsTableProps> = ({
       <MultiColumnList
         interactive
         data-testid="ItemsList"
-        contentData={content}
+        contentData={content ?? []}
         visibleColumns={LISTS_VISIBLE_COLUMNS}
         formatter={listTableResultFormatter}
-        pagingType={null}
         pageAmount={totalPages}
         totalCount={totalRecords}
         onNeedMoreData={onNeedMoreData}

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,11 +1,10 @@
-declare module '@folio/stripes/components';
-declare module '@folio/stripes/smart-components';
-declare module '@folio/stripes/core';
 declare module '@folio/stripes-acq-components';
+
 declare module '*.css' {
   const styles: { [className: string]: string };
   export = styles;
 }
+
 declare module '*.json' {
   const value: any;
   export default value;

--- a/src/hooks/useRecordsLimit/useRecordsLimit.ts
+++ b/src/hooks/useRecordsLimit/useRecordsLimit.ts
@@ -7,7 +7,8 @@ type RecordsLimit = {
 
 export const useRecordsLimit = () => {
   const ky = useOkapiKy();
-  const { data } = useQuery({
+
+  const { data } = useQuery<RecordsLimit, unknown, number>({
     queryKey: ['refreshLimit'],
     queryFn: () => ky.get('lists/configuration').json(),
     retry: false,

--- a/src/hooks/useRefresh/useInitRefresh/useInitRefresh.ts
+++ b/src/hooks/useRefresh/useInitRefresh/useInitRefresh.ts
@@ -11,7 +11,12 @@ type useInitRefreshProps = {
 export const useInitRefresh = ({ onSuccess, onError }: useInitRefreshProps) => {
   const ky = useOkapiKy();
 
-  const { mutate: initRefresh, reset, isLoading } = useMutation((listId: string) => ky.post(`lists/${listId}/refresh`).json(),
+  const {
+    mutate: initRefresh,
+    reset,
+    isLoading,
+  } = useMutation<InitRefreshResponse, HTTPError, string>(
+    (listId: string) => ky.post(`lists/${listId}/refresh`).json(),
     {
       retry: false,
       onSuccess: (data: InitRefreshResponse) => {
@@ -21,8 +26,9 @@ export const useInitRefresh = ({ onSuccess, onError }: useInitRefreshProps) => {
       onError: (error: HTTPError) => {
         onError?.(error);
         reset();
-      }
-    });
+      },
+    },
+  );
 
   return {
     initRefresh,
@@ -30,5 +36,3 @@ export const useInitRefresh = ({ onSuccess, onError }: useInitRefreshProps) => {
     initRefreshInProgress: isLoading
   };
 };
-
-

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -20,10 +16,6 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": [
-    "src", "**/*.ts", "**/*.tsx", "**/*.test.ts", "**/*.test.tsx"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src", "**/*.ts", "**/*.tsx", "**/*.test.ts", "**/*.test.tsx"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
# [Jira UILISTS-49](https://issues.folio.org/browse/UILISTS-49)

## Purpose

In the early days of TypeScript in FOLIO, typings for the stripes-* libraries were self-contained within each module.  This was fine when only one or two modules used TypeScript, however, it quickly became unmaintainable, especially when conflicts arose.  We decided to get around this by simply adding a dependence on `@folio/calendar`, but now that `ui-calendar` is removing these typings (https://github.com/folio-org/ui-calendar/pull/508), it's time for us to do so, too.

As a result of all this, we created https://github.com/folio-org/stripes-types as a centralized location for all modules to share their typings.  Since the ones in ui-bulk-edit are now hosted there, they should be removed from the all UI modules themselves.

## Approach

Remove the dependency and declarations of stripes modules.  `stripes-acq-components` will need this treatment too, but that'll be on a future date [once UISACQCOMP-175 is merged](https://issues.folio.org/browse/UISACQCOMP-175).

This did reveal one issue: `DropdownMenu` requires an `onToggle` prop, so we've added that.