### PR TITLE
[UILISTS-92] Fix incorrect types for CheckboxFilter

### DIFF
--- a/src/interfaces/entity.ts
+++ b/src/interfaces/entity.ts
@@ -34,3 +34,12 @@ export interface EntityType {
     label: string;
     columns: EntityTypeColumn[];
 }
+
+export interface QueryBuilderColumnMetadata {
+    label: string;
+    value: string;
+    disabled: false;
+    readOnly: false;
+    selected: boolean;
+    dataType: string;
+}

--- a/src/pages/listInformation/ListInformationPage.tsx
+++ b/src/pages/listInformation/ListInformationPage.tsx
@@ -22,7 +22,7 @@ import {
 } from './components';
 
 import { HOME_PAGE_URL } from '../../constants';
-import { EntityTypeColumn } from '../../interfaces';
+import { QueryBuilderColumnMetadata } from '../../interfaces';
 
 import { ConfirmDeleteModal, CompilingLoader, ErrorComponent } from '../../components';
 import { USER_PERMS } from '../../utils/constants';
@@ -115,7 +115,7 @@ export const ListInformationPage: React.FC = () => {
   const closeSuccessMessage = () => {
     setShowSuccessRefreshMessage(false);
   };
-  const [columnControls, setColumnControls] = useState<EntityTypeColumn[]>([]);
+  const [columnControls, setColumnControls] = useState<QueryBuilderColumnMetadata[]>([]);
 
   const {
     handleColumnsChange,
@@ -218,7 +218,6 @@ export const ListInformationPage: React.FC = () => {
               visibleColumns={visibleColumns}
               columns={columnControls}
               onColumnsChange={handleColumnsChange}
-              // @ts-ignore:next-line
               buttonHandlers={buttonHandlers}
               conditions={conditions}
             />}

--- a/src/pages/listInformation/components/ListInformationMenu/ListInformationMenu.test.tsx
+++ b/src/pages/listInformation/components/ListInformationMenu/ListInformationMenu.test.tsx
@@ -18,7 +18,8 @@ const mockProps: ListInformationMenuProps = {
     'cancel-export': jest.fn()
   },
   conditions: { isListCanned: false },
-  onColumnsChange: jest.fn()
+  onColumnsChange: jest.fn(),
+  columns: [],
 };
 
 beforeEach(() => {

--- a/src/pages/listInformation/components/ListInformationMenu/ListInformationMenu.tsx
+++ b/src/pages/listInformation/components/ListInformationMenu/ListInformationMenu.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-// @ts-ignore:next-line
 import { CheckboxFilter } from '@folio/stripes/smart-components';
 import {
   Headline
@@ -14,12 +13,12 @@ import { t,
   isExportDisabled,
   DisablingConditions } from '../../../../services';
 import { ActionMenu } from '../../../../components';
-import { EntityTypeColumn, ICONS } from '../../../../interfaces';
+import { ICONS, QueryBuilderColumnMetadata } from '../../../../interfaces';
 import { USER_PERMS } from '../../../../utils/constants';
 
 export interface ListInformationMenuProps {
   stripes: any,
-  columns?: EntityTypeColumn[]
+  columns: QueryBuilderColumnMetadata[]
   visibleColumns?: string[] | null,
   buttonHandlers: {
     'cancel-refresh': () => void,
@@ -126,12 +125,10 @@ export const ListInformationMenu: React.FC<ListInformationMenuProps> = ({
         {t('pane.dropdown.show-columns')}
       </Headline>
       <CheckboxFilter
-        // @ts-ignore:next-line
         dataOptions={columns}
         name="ui-lists-columns-filter"
-        // @ts-ignore:next-line
         onChange={onColumnsChange}
-        selectedValues={visibleColumns}
+        selectedValues={visibleColumns ?? []}
       />
     </ActionMenu>
   );

--- a/src/pages/listInformation/components/ListInformationResultViewer/ListInformationResultViewer.tsx
+++ b/src/pages/listInformation/components/ListInformationResultViewer/ListInformationResultViewer.tsx
@@ -2,18 +2,18 @@ import React from 'react';
 // @ts-ignore:next-line
 import { Pluggable, useOkapiKy } from '@folio/stripes/core';
 import { t } from '../../../../services';
-import { EntityTypeColumn } from '../../../../interfaces';
+import { QueryBuilderColumnMetadata } from '../../../../interfaces';
 
 type ListInformationResultViewerType = {
-  userFriendlyQuery?: string,
-  refreshTrigger?: number | boolean,
-  setColumnControlList?: (columns:EntityTypeColumn[]) => void,
-  setDefaultVisibleColumns?: (columns:string[]) => void,
-  listID?: string,
-  entityTypeId?: string,
-  visibleColumns?: string[] | null,
-  refreshInProgress: boolean
-}
+  userFriendlyQuery?: string;
+  refreshTrigger?: number | boolean;
+  setColumnControlList?: (columns: QueryBuilderColumnMetadata[]) => void;
+  setDefaultVisibleColumns?: (columns: string[]) => void;
+  listID?: string;
+  entityTypeId?: string;
+  visibleColumns?: string[] | null;
+  refreshInProgress: boolean;
+};
 
 
 export const ListInformationResultViewer: React.FC<ListInformationResultViewerType> = ({


### PR DESCRIPTION
# [Jira UILISTS-92](https://issues.folio.org/browse/UILISTS-92)

The query builder does not provide entity type columns straight from mod-fqm; instead, [it transforms them into a different schema for use in `CheckboxFilter`](https://github.com/folio-org/ui-plugin-query-builder/blob/master/src/QueryBuilder/ResultViewer/helpers.js#L4).  This PR changes the type to use the proper types.

Since the query builder is an external module and does not use typescript, we unfortunately had no way of knowing we were specifying the wrong type.  However, as more of Stripes adds TS typings, we'll be able to catch bugs like this in the future with ease.