### PR TITLE
Add redirect from empty page

### DIFF
--- a/src/components/ListsTable/ListsTable.tsx
+++ b/src/components/ListsTable/ListsTable.tsx
@@ -28,7 +28,16 @@ export const ListsTable: FC<ListsTableProps> = ({
     offset: storedCurrentPageOffset,
   });
 
+  const goToLastPage = (totalPages: number) => {
+    const lastPageOffset = PAGINATION_AMOUNT * (totalPages - 1);
+
+    onNeedMoreData({
+      offset: lastPageOffset
+    })
+  }
+
   const onNeedMoreData = (thePagination: any) => {
+    console.log(thePagination);
     writeStorage(CURRENT_PAGE_OFFSET_KEY, thePagination.offset);
     // @ts-ignore:next-line
     changePage(thePagination);
@@ -50,8 +59,14 @@ export const ListsTable: FC<ListsTableProps> = ({
   const { listsData, isLoading } = useLists({ filters: activeFilters, size: pagination?.limit, offset: pagination?.offset });
 
   useEffect(() => {
+    if(isLoading) {
+      return
+    }
+
     if (listsData?.content?.length) {
       setRecordIds(listsData?.content.map(({ id }) => id));
+    } else if (listsData?.totalPages){
+      goToLastPage(listsData?.totalPages)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [listsData]);
@@ -85,7 +100,6 @@ export const ListsTable: FC<ListsTableProps> = ({
         formatter={listTableResultFormatter}
         pageAmount={totalPages}
         totalCount={totalRecords}
-        onNeedMoreData={onNeedMoreData}
         columnMapping={listTableMapping}
       />
       <PrevNextPagination

--- a/src/components/ListsTable/ListsTable.tsx
+++ b/src/components/ListsTable/ListsTable.tsx
@@ -28,8 +28,10 @@ export const ListsTable: FC<ListsTableProps> = ({
     offset: storedCurrentPageOffset,
   });
 
-  const goToLastPage = (totalPages: number) => {
-    const lastPageOffset = PAGINATION_AMOUNT * (totalPages - 1);
+  const goToLastPage = (totalPages: number = 0) => {
+    const lastPageOffset = totalPages > 1
+      ? PAGINATION_AMOUNT * (totalPages - 1)
+      : 0;
 
     onNeedMoreData({
       offset: lastPageOffset


### PR DESCRIPTION
Implementation of [UILISTS-62](https://issues.folio.org/browse/UILISTS-62)
Add logic to track cases when the user is on the empty list landing page and redirect to the last available page.

The list page demands refactoring, so additional tests will be added in [UILISTS-66](https://issues.folio.org/browse/UILISTS-66)

https://github.com/folio-org/ui-lists/assets/17111248/442f3483-2563-4f23-b438-d878b868a891
