### PR TITLE
Add column width configuration

### DIFF
--- a/src/components/ListsTable/ListsTable.tsx
+++ b/src/components/ListsTable/ListsTable.tsx
@@ -99,7 +99,6 @@ export const ListsTable: FC<ListsTableProps> = ({
         interactive
         data-testid="ItemsList"
         contentData={content ?? []}
-        // @ts-ignore:next-line
         columnWidths={columnWidthsConfig}
         visibleColumns={LISTS_VISIBLE_COLUMNS}
         formatter={listTableResultFormatter}

--- a/src/components/ListsTable/ListsTable.tsx
+++ b/src/components/ListsTable/ListsTable.tsx
@@ -10,6 +10,7 @@ import { listTableResultFormatter } from './helpers/formatters';
 import { LISTS_VISIBLE_COLUMNS } from '../../constants';
 import { useLists, useListsIdsToTrack, usePrevious } from '../../hooks';
 import { CURRENT_PAGE_OFFSET_KEY, PAGINATION_AMOUNT } from '../../utils/constants';
+import { columnWidthsConfig } from "./configs";
 
 export interface ListsTableProps {
   activeFilters: string[],
@@ -98,6 +99,8 @@ export const ListsTable: FC<ListsTableProps> = ({
         interactive
         data-testid="ItemsList"
         contentData={content ?? []}
+        // @ts-ignore:next-line
+        columnWidths={columnWidthsConfig}
         visibleColumns={LISTS_VISIBLE_COLUMNS}
         formatter={listTableResultFormatter}
         pageAmount={totalPages}

--- a/src/components/ListsTable/configs.ts
+++ b/src/components/ListsTable/configs.ts
@@ -4,4 +4,4 @@ export const columnWidthsConfig = {
   [COLUMNS_NAME.LIST_NAME]: '250px',
   [COLUMNS_NAME.SOURCE]: '170px',
   [COLUMNS_NAME.RECORD_TYPE]: '200px'
-}
+} as const;

--- a/src/components/ListsTable/configs.ts
+++ b/src/components/ListsTable/configs.ts
@@ -1,0 +1,7 @@
+import {COLUMNS_NAME} from "../../constants";
+
+export const columnWidthsConfig = {
+  [COLUMNS_NAME.LIST_NAME]: '250px',
+  [COLUMNS_NAME.SOURCE]: '170px',
+  [COLUMNS_NAME.RECORD_TYPE]: '200px'
+}

--- a/src/constants/columns.ts
+++ b/src/constants/columns.ts
@@ -8,5 +8,5 @@ export const COLUMNS_NAME = {
   SOURCE: 'createdByUsername',
   LAST_UPDATED: 'updatedDate',
   VISIBILITY: 'isPrivate',
-};
+} as const;
 export const LISTS_VISIBLE_COLUMNS = Object.values(COLUMNS_NAME) as (keyof ListsRecord)[];


### PR DESCRIPTION
Implementation of [UILISTS-105](https://folio-org.atlassian.net/browse/UILISTS-105)
Added width config for List name, Record type, and Source columns

<img width="850" alt="Screenshot 2024-02-21 at 18 00 30" src="https://github.com/folio-org/ui-lists/assets/17111248/b3eea630-8e1f-4909-898e-6e4517f280b4">
