### PR TITLE
Add entity type to list details and edit pages

### DIFF
--- a/src/components/MainListInfoForm/MainListInfoForm.tsx
+++ b/src/components/MainListInfoForm/MainListInfoForm.tsx
@@ -57,16 +57,18 @@ export const MainListInfoForm = (
   const showInactiveRadioWarning = showInactiveWarning && isStatusChanged && status === STATUS_VALUES.INACTIVE;
   const activeRadioWarning = showInactiveRadioWarning ? t('warning.inactive-status') : '';
   const renderRecordType = () => {
-    return (
-      <Row>
-        <Col xs={2}>
-          <KeyValue
-            label={t("list.info.record-type")}
-            value={recordTypeLabel}
-          />
-        </Col>
-      </Row>
-    )
+    if(recordTypeLabel) {
+      return (
+        <Row>
+          <Col xs={2}>
+            <KeyValue
+              label={t("list.info.record-type")}
+              value={recordTypeLabel}
+            />
+          </Col>
+        </Row>
+      )
+    }
   }
   const renderSelect = () => {
     if (recordTypeOptions?.length) {

--- a/src/components/MainListInfoForm/MainListInfoForm.tsx
+++ b/src/components/MainListInfoForm/MainListInfoForm.tsx
@@ -1,5 +1,4 @@
 import React, { ChangeEvent, useState, FocusEvent } from 'react';
-// @ts-ignore:next-line
 import {
   Layout,
   RadioButton,

--- a/src/components/MainListInfoForm/MainListInfoForm.tsx
+++ b/src/components/MainListInfoForm/MainListInfoForm.tsx
@@ -1,6 +1,16 @@
 import React, { ChangeEvent, useState, FocusEvent } from 'react';
 // @ts-ignore:next-line
-import { Layout, RadioButton, RadioButtonGroup, TextArea, TextField, Select, InfoPopover } from '@folio/stripes/components';
+import {
+  Layout,
+  RadioButton,
+  RadioButtonGroup,
+  TextArea,
+  TextField,
+  Col,
+  KeyValue,
+  Row,
+  Select,
+  InfoPopover } from '@folio/stripes/components';
 import { FIELD_NAMES, STATUS_VALUES, VISIBILITY_VALUES } from './type';
 import { EntityTypeSelectOption } from '../../interfaces';
 import {
@@ -19,7 +29,8 @@ type MainListInfoFormProps = {
     status: string,
     isLoading?: boolean,
     showInactiveWarning?: boolean,
-    recordTypeOptions?: EntityTypeSelectOption[]
+    recordTypeOptions?: EntityTypeSelectOption[],
+    recordTypeLabel?: string;
 }
 
 export const MainListInfoForm = (
@@ -30,7 +41,8 @@ export const MainListInfoForm = (
     visibility,
     status,
     isLoading,
-    recordTypeOptions }: MainListInfoFormProps
+    recordTypeOptions,
+    recordTypeLabel}: MainListInfoFormProps
 ) => {
   const onChangeHandler = (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     onValueChange({ [event.target.name]: event.target.value });
@@ -45,7 +57,18 @@ export const MainListInfoForm = (
 
   const showInactiveRadioWarning = showInactiveWarning && isStatusChanged && status === STATUS_VALUES.INACTIVE;
   const activeRadioWarning = showInactiveRadioWarning ? t('warning.inactive-status') : '';
-
+  const renderRecordType = () => {
+    return (
+      <Row>
+        <Col xs={2}>
+          <KeyValue
+            label={t("list.info.record-type")}
+            value={recordTypeLabel}
+          />
+        </Col>
+      </Row>
+    )
+  }
   const renderSelect = () => {
     if (recordTypeOptions?.length) {
       /**
@@ -99,6 +122,7 @@ export const MainListInfoForm = (
         label={t('create-list.main.list-description')}
       />
       {renderSelect()}
+      {renderRecordType()}
       <Layout className="display-flex flex-align-items-start">
         <RadioButtonGroup
           value={visibility}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -12,3 +12,4 @@ export { useLocalStorageToggle } from './useLocalStorageToggle';
 export { usePrevious } from './usePrevious';
 export { useVisibleColumns } from './useVisibleColumns';
 export { useCreateList } from './useCreateList';
+export { useRecordTypeLabel } from "./useRecordTypeLabel";

--- a/src/hooks/useRecordTypeLabel/index.ts
+++ b/src/hooks/useRecordTypeLabel/index.ts
@@ -1,0 +1,1 @@
+export { useRecordTypeLabel } from "./useRecordTypeLabel";

--- a/src/hooks/useRecordTypeLabel/useRecordTypeLabel.tsx
+++ b/src/hooks/useRecordTypeLabel/useRecordTypeLabel.tsx
@@ -4,5 +4,5 @@ import {useRecordTypes} from '../useRecordTypes';
 export const useRecordTypeLabel = (targetID: string = '') => {
   const { recordTypes = [] } = useRecordTypes();
 
-  return recordTypes.find(({id}) => id === targetID)?.label || '';
+  return recordTypes.find(({id}) => id === targetID)?.label ?? '';
 }

--- a/src/hooks/useRecordTypeLabel/useRecordTypeLabel.tsx
+++ b/src/hooks/useRecordTypeLabel/useRecordTypeLabel.tsx
@@ -1,0 +1,8 @@
+import {useRecordTypes} from '../useRecordTypes';
+
+
+export const useRecordTypeLabel = (targetID: string = '') => {
+  const { recordTypes = [] } = useRecordTypes();
+
+  return recordTypes.find(({id}) => id === targetID)?.label || '';
+}

--- a/src/pages/editlist/EditListPage.tsx
+++ b/src/pages/editlist/EditListPage.tsx
@@ -11,7 +11,7 @@ import { useStripes } from '@folio/stripes/core';
 import { useHistory, useParams } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 import { HTTPError } from 'ky';
-import { useCSVExport, useDeleteList, useListDetails, useMessages } from '../../hooks';
+import {useCSVExport, useDeleteList, useListDetails, useMessages, useRecordTypeLabel} from '../../hooks';
 import { t, computeErrorMessage, isInactive, isInDraft, isCanned, isEmptyList } from '../../services';
 import {
   MainListInfoForm,
@@ -36,6 +36,8 @@ export const EditListPage:FC = () => {
   const { data: listDetails, isLoading: loadingListDetails, detailsError } = useListDetails(id);
 
   const listName = listDetails?.name ?? '';
+
+  const recordTypeLabel = useRecordTypeLabel(listDetails?.entityTypeId);
 
   const { showSuccessMessage, showErrorMessage } = useMessages();
   const { state, hasChanges, onValueChange, isListBecameActive } = useEditListFormState(listDetails, loadingListDetails);
@@ -187,6 +189,7 @@ export const EditListPage:FC = () => {
               visibility={state[FIELD_NAMES.VISIBILITY]}
               description={state[FIELD_NAMES.DESCRIPTION]}
               isLoading={loadingListDetails}
+              recordTypeLabel={recordTypeLabel}
               showInactiveWarning
             />
           </Layout>

--- a/src/pages/listInformation/ListInformationPage.tsx
+++ b/src/pages/listInformation/ListInformationPage.tsx
@@ -13,7 +13,7 @@ import { useIntl } from 'react-intl';
 import { useQueryClient } from 'react-query';
 import { useStripes } from '@folio/stripes/core';
 import { t, isInactive, isInDraft, isCanned, computeErrorMessage, isEmptyList } from '../../services';
-import { useListDetails, useRefresh, useDeleteList, useCSVExport, useMessages, useVisibleColumns } from '../../hooks';
+import { useListDetails, useRefresh, useDeleteList, useCSVExport, useMessages, useVisibleColumns, useRecordTypeLabel } from '../../hooks';
 import {
   ListAppIcon, ListInformationMenu,
   MetaSectionAccordion,
@@ -36,6 +36,7 @@ export const ListInformationPage: React.FC = () => {
   const { data: listData, isLoading: isDetailsLoading, refetchDetails, detailsError } = useListDetails(id);
   const { name: listName = '' } = listData ?? {};
   const [refreshTrigger, setRefreshTrigger] = useState(uniqueId());
+  const recordTypeLabel = useRecordTypeLabel(listData?.entityTypeId);
 
   const { requestExport, isExportInProgress, isCancelExportInProgress, cancelExport } = useCSVExport({
     listId: id,
@@ -229,7 +230,7 @@ export const ListInformationPage: React.FC = () => {
             />}
           >
             <AccordionSet>
-              <MetaSectionAccordion listInfo={listData} />
+              <MetaSectionAccordion listInfo={listData} recordType={recordTypeLabel}/>
             </AccordionSet>
 
             <AccordionSet>

--- a/src/pages/listInformation/components/MetaSectionAccordion/MetaSectionAccordion.tsx
+++ b/src/pages/listInformation/components/MetaSectionAccordion/MetaSectionAccordion.tsx
@@ -8,13 +8,15 @@ import {
   MetaSection
 } from '@folio/stripes/components';
 import { FormattedMessage } from 'react-intl';
+import { t } from '../../../../services';
 import { ListsRecordDetails } from '../../../../interfaces';
 
 interface MetaSectionAccordionProps {
-  listInfo?: ListsRecordDetails
+  listInfo?: ListsRecordDetails,
+  recordType: string
 }
 
-export const MetaSectionAccordion: React.FC<MetaSectionAccordionProps> = ({ listInfo }) => {
+export const MetaSectionAccordion: React.FC<MetaSectionAccordionProps> = ({ listInfo, recordType }) => {
   const listSource = listInfo?.isCanned ? (
     <FormattedMessage id="ui-lists.list.info.source.system" />
   ) : (
@@ -24,7 +26,7 @@ export const MetaSectionAccordion: React.FC<MetaSectionAccordionProps> = ({ list
   return (
     <Accordion
       data-testid="metaSectionAccordion"
-      label={<FormattedMessage id="ui-lists.accordion.title.list-information" />}
+      label={t("accordion.title.list-information")}
     >
       <MetaSection
         contentId="userInfoRecordMetaContent"
@@ -41,44 +43,39 @@ export const MetaSectionAccordion: React.FC<MetaSectionAccordionProps> = ({ list
         value={listInfo?.name}
       />
       <KeyValue
-        label={<FormattedMessage
-          id="ui-lists.list.info.description"
-        />}
+        label={t("list.info.description")}
         value={listInfo?.description}
       />
 
       <Row>
         <Col xs={2}>
           <KeyValue
-            label={<FormattedMessage
-              id="ui-lists.list.info.visibility"
-            />}
-            value={(
-              <FormattedMessage id={listInfo?.isPrivate
-                ? 'ui-lists.lists.item.private'
-                : 'ui-lists.lists.item.shared'}
-              />
+            label={t("list.info.record-type")}
+            value={recordType}
+          />
+        </Col>
+        <Col xs={2}>
+          <KeyValue
+            label={t("list.info.visibility")}
+            value={
+              t(listInfo?.isPrivate
+                ? "lists.item.private"
+                : "lists.item.shared"
+
             )}
           />
         </Col>
         <Col xs={2}>
           <KeyValue
-            label={<FormattedMessage
-              id="ui-lists.list.info.status"
-            />}
-            value={(
-              <FormattedMessage id={listInfo?.isActive
-                ? 'ui-lists.lists.item.active'
-                : 'ui-lists.lists.item.inactive'}
-              />
-            )}
+            label={t("list.info.status")}
+            value={t(listInfo?.isActive
+                ? "lists.item.active"
+                : "lists.item.inactive")}
           />
         </Col>
         <Col xs={2}>
           <KeyValue
-            label={<FormattedMessage
-              id="ui-lists.list.info.source"
-            />}
+            label={t("list.info.source")}
             value={listSource}
           />
         </Col>

--- a/translations/ui-lists/en.json
+++ b/translations/ui-lists/en.json
@@ -30,6 +30,8 @@
   "list.info.visibility": "Visibility",
   "list.info.status": "Status",
   "list.info.source": "Source",
+  "list.info.record-type": "Record type",
+
 
   "list.info.source.system": "System",
 


### PR DESCRIPTION
Implementation of [UILISTS-98](https://folio-org.atlassian.net/browse/UILISTS-98)
Added entity type to edit page and list details page
<img width="554" alt="Screenshot 2024-02-28 at 18 46 56" src="https://github.com/folio-org/ui-lists/assets/17111248/b08c9620-5fc0-4c29-bf34-84d6ef6ab7e2">
<img width="773" alt="Screenshot 2024-02-28 at 18 47 05" src="https://github.com/folio-org/ui-lists/assets/17111248/aa6d061a-00c7-4541-a427-9e4ad94ff6dc">
