### PR TITLE
[UILISTS-75] Show query when duplicating a list

### DIFF
--- a/src/components/EditListLayout/EditListLayout.tsx
+++ b/src/components/EditListLayout/EditListLayout.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactElement } from 'react';
+import React, { FC, ReactElement, ReactNode } from 'react';
 import { useIntl } from 'react-intl';
 import { isNumber } from 'lodash';
 import { Button, Layer, Loading, Pane, PaneFooter, Paneset } from '@folio/stripes/components';
@@ -10,7 +10,7 @@ type EditListLayoutProps = {
   isLoading?: boolean;
   onCancel?: () => void;
   onSave?: () => void;
-  children?: ReactElement[],
+  children?: ReactNode,
   name: string,
   title: string | ReactElement,
   recordsCount?: number,

--- a/src/components/EditListResultViewer/EditListResultViewer.tsx
+++ b/src/components/EditListResultViewer/EditListResultViewer.tsx
@@ -1,25 +1,26 @@
-// @ts-ignore
-import { useOkapiKy, Pluggable } from '@folio/stripes/core';
+import { Pluggable, useOkapiKy } from '@folio/stripes/core';
 import React, { FC } from 'react';
+import { useVisibleColumns } from '../../hooks';
+import { STATUS_VALUES, VISIBILITY_VALUES } from '../../interfaces';
 import { t } from '../../services';
 import { ConfigureQuery } from '../ConfigureQuery';
-import { useVisibleColumns } from "../../hooks";
-import { STATUS_VALUES, VISIBILITY_VALUES } from '../../interfaces';
 
 import css from './EditListResultViewer.module.css';
 
-type EditListResultViewerProps = {
-    id: string,
-    version: number,
-    entityTypeId: string,
-    fqlQuery: string,
-    userFriendlyQuery: string,
-    contentVersion: number,
-    fields?: string[],
-    status: string,
-    listName: string,
-    visibility: string,
-    description: string
+interface EditListResultViewerProps {
+  id: string,
+  version?: number,
+  entityTypeId?: string,
+  fqlQuery: string,
+  userFriendlyQuery: string,
+  contentVersion: number,
+  fields?: string[],
+  status: string,
+  listName: string,
+  visibility: string,
+  description: string,
+  isDuplicating?: boolean,
+  isQueryButtonDisabled?: boolean,
 }
 
 export const EditListResultViewer:FC<EditListResultViewerProps> = (
@@ -34,7 +35,9 @@ export const EditListResultViewer:FC<EditListResultViewerProps> = (
     listName,
     visibility,
     description,
-    fields
+    fields,
+    isDuplicating = false,
+    isQueryButtonDisabled = false
   }
 ) => {
   const ky = useOkapiKy();
@@ -70,13 +73,13 @@ export const EditListResultViewer:FC<EditListResultViewerProps> = (
       additionalControls={(
         <div className={css.queryBuilderButton}>
           <ConfigureQuery
-            listId={id}
-            version={version}
-            isEditQuery
+            listId={isDuplicating ? undefined : id}
+            version={isDuplicating ? undefined : version}
+            isEditQuery={!isDuplicating}
             initialValues={fqlQuery ? JSON.parse(fqlQuery) : undefined}
             selectedType={entityTypeId}
             recordColumns={fields}
-            isQueryButtonDisabled={false}
+            isQueryButtonDisabled={isQueryButtonDisabled}
             listName={listName}
             status={status === STATUS_VALUES.ACTIVE ? STATUS_VALUES.ACTIVE : STATUS_VALUES.INACTIVE}
             visibility={visibility === VISIBILITY_VALUES.SHARED ? VISIBILITY_VALUES.SHARED : VISIBILITY_VALUES.PRIVATE}

--- a/src/pages/copylist/CopyListPage.module.css
+++ b/src/pages/copylist/CopyListPage.module.css
@@ -1,3 +1,0 @@
-.queryBuilderButton {
-    width: 110px;
-}

--- a/src/pages/copylist/CopyListPage.tsx
+++ b/src/pages/copylist/CopyListPage.tsx
@@ -6,12 +6,10 @@ import { useHistory, useParams } from 'react-router-dom';
 import { HTTPError } from 'ky';
 import { useCreateList, useInitRefresh, useListDetails, useMessages } from '../../hooks';
 import { computeErrorMessage, t } from '../../services';
-import { ConfigureQuery, EditListLayout, ErrorComponent, MainListInfoForm } from '../../components';
+import { EditListLayout, EditListResultViewer, ErrorComponent, MainListInfoForm } from '../../components';
 import { useCopyListFormState } from './hooks';
 import { FIELD_NAMES, ListsRecordBase, STATUS_VALUES } from '../../interfaces';
 import { HOME_PAGE_URL } from '../../constants';
-
-import css from './CopyListPage.module.css';
 
 export const CopyListPage:FC = () => {
   const history = useHistory();
@@ -111,18 +109,22 @@ export const CopyListPage:FC = () => {
             </Layout>
           </Accordion>
         </AccordionSet>
-        <div className={css.queryBuilderButton}>
-          <ConfigureQuery
-            initialValues={fqlQuery && JSON.parse(fqlQuery)}
-            selectedType={listDetails?.entityTypeId}
-            isQueryButtonDisabled={hasName || isLoading}
-            listName={state[FIELD_NAMES.LIST_NAME]}
-            status={state[FIELD_NAMES.STATUS]}
-            visibility={state[FIELD_NAMES.VISIBILITY]}
-            description={state[FIELD_NAMES.DESCRIPTION]}
-            recordColumns={listDetails?.fields}
-          />
-        </div>
+
+        <EditListResultViewer
+          isDuplicating
+          id={id}
+          version={listDetails?.version}
+          fields={listDetails?.fields}
+          fqlQuery={listDetails?.fqlQuery ?? ''}
+          userFriendlyQuery={listDetails?.userFriendlyQuery ?? ''}
+          contentVersion={listDetails?.successRefresh?.contentVersion ?? 0}
+          entityTypeId={listDetails?.entityTypeId}
+          status={state[FIELD_NAMES.STATUS]}
+          listName={state[FIELD_NAMES.LIST_NAME]}
+          visibility={state[FIELD_NAMES.VISIBILITY]}
+          description={state[FIELD_NAMES.DESCRIPTION]}
+          isQueryButtonDisabled={hasName || isLoading}
+        />
       </EditListLayout>
     </TitleManager>
   );


### PR DESCRIPTION
This was relatively straightforward, abstracting the existing `EditListResultViewer` (responsible for this part on the edit page:
![image](https://github.com/folio-org/ui-lists/assets/8005215/7510420c-3a61-4f64-8f96-92e14338439b)
)