### PR TITLE
UILISTS-109: Send list of selected columns as parameter to GET /lists/{listId}/contents API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Send list of columns when exporting a list. Refs [UILISTS-110]
 * Bump up stripes-acq-components from 5.0.0 to 5.1.0
 * Improve exception handling. Refs [UILISTS-121]
+* Send list of selected columns as parameter to GET /lists/{listId}/contents API. Refs [UILISTS-109]
 
 [UILISTS-9]: https://folio-org.atlassian.net/browse/UILISTS-9
 [UILISTS-2]: https://folio-org.atlassian.net/browse/UILISTS-2
@@ -42,6 +43,7 @@
 [UILISTS-80]: https://folio-org.atlassian.net/browse/UILISTS-80
 [UILISTS-110]: https://folio-org.atlassian.net/browse/UILISTS-110
 [UILISTS-121]: https://folio-org.atlassian.net/browse/UILISTS-121
+[UILISTS-109]: https://folio-org.atlassian.net/browse/UILISTS-109
 
 ## 2.0.x
 

--- a/src/components/EditListResultViewer/EditListResultViewer.tsx
+++ b/src/components/EditListResultViewer/EditListResultViewer.tsx
@@ -1,3 +1,4 @@
+// @ts-ignore
 import { Pluggable, useOkapiKy } from '@folio/stripes/core';
 import React, { FC } from 'react';
 import { useVisibleColumns } from '../../hooks';
@@ -47,7 +48,7 @@ export const EditListResultViewer:FC<EditListResultViewerProps> = (
   } = useVisibleColumns(id);
 
   const getAsyncContentData = ({ limit, offset }: any) => {
-    return ky.get(`lists/${id}/contents?offset=${offset}&size=${limit}`).json();
+    return ky.get(`lists/${id}/contents?offset=${offset}&size=${limit}&fields=${visibleColumns?.join(',')}`).json();
   };
 
   const getAsyncEntityType = () => {
@@ -69,6 +70,7 @@ export const EditListResultViewer:FC<EditListResultViewerProps> = (
       entityTypeDataSource={getAsyncEntityType}
       visibleColumns={visibleColumns}
       onSetDefaultColumns={() => {}}
+      contentQueryKeys={visibleColumns}
       height={500}
       additionalControls={(
         <div className={css.queryBuilderButton}>

--- a/src/pages/listInformation/components/ListInformationResultViewer/ListInformationResultViewer.tsx
+++ b/src/pages/listInformation/components/ListInformationResultViewer/ListInformationResultViewer.tsx
@@ -29,7 +29,7 @@ export const ListInformationResultViewer: React.FC<ListInformationResultViewerTy
   const ky = useOkapiKy();
 
   const getAsyncContentData = ({ limit, offset }: any) => {
-    return ky.get(`lists/${listID}/contents?offset=${offset}&size=${limit}`).json();
+    return ky.get(`lists/${listID}/contents?offset=${offset}&size=${limit}&fields=${visibleColumns?.join(',')}`).json();
   };
 
   const getAsyncEntityType = () => {
@@ -53,6 +53,7 @@ export const ListInformationResultViewer: React.FC<ListInformationResultViewerTy
       onSetDefaultVisibleColumns={setDefaultVisibleColumns}
       onSetDefaultColumns={setColumnControlList}
       height={500}
+      contentQueryKeys={visibleColumns}
     >
       No loaded
     </Pluggable>


### PR DESCRIPTION
[UILISTS-109](https://folio-org.atlassian.net/browse/UILISTS-109)]
Here we pass visible columns to plugin to update query key. Also endpoint `/lists/{listId}/contents` was updated