### PR TITLE
Add record type in to Duplicate a List page

### DIFF
--- a/src/pages/copylist/CopyListPage.tsx
+++ b/src/pages/copylist/CopyListPage.tsx
@@ -4,7 +4,7 @@ import { Accordion, AccordionSet, Layout, Loading } from '@folio/stripes/compone
 import { TitleManager } from '@folio/stripes/core';
 import { useHistory, useParams } from 'react-router-dom';
 import { HTTPError } from 'ky';
-import { useCreateList, useInitRefresh, useListDetails, useMessages } from '../../hooks';
+import {useCreateList, useInitRefresh, useListDetails, useMessages, useRecordTypeLabel} from '../../hooks';
 import { computeErrorMessage, t } from '../../services';
 import { EditListLayout, EditListResultViewer, ErrorComponent, MainListInfoForm } from '../../components';
 import { useCopyListFormState } from './hooks';
@@ -16,6 +16,7 @@ export const CopyListPage:FC = () => {
   const intl = useIntl();
   const { id }: {id: string} = useParams();
   const { data: listDetails, isLoading: loadingListDetails, detailsError } = useListDetails(id);
+  const recordTypeLabel = useRecordTypeLabel(listDetails?.entityTypeId);
 
   const listName = listDetails?.name ?? '';
   const fqlQuery = listDetails?.fqlQuery ?? '';
@@ -104,6 +105,7 @@ export const CopyListPage:FC = () => {
                 listName={state[FIELD_NAMES.LIST_NAME]}
                 visibility={state[FIELD_NAMES.VISIBILITY]}
                 description={state[FIELD_NAMES.DESCRIPTION]}
+                recordTypeLabel={recordTypeLabel}
                 isLoading={loadingListDetails}
               />
             </Layout>


### PR DESCRIPTION
Implementation of [UILISTS-136](https://folio-org.atlassian.net/browse/UILISTS-136)
Add record type label for Duplicate a List page
<img width="658" alt="Screenshot 2024-05-20 at 17 06 33" src="https://github.com/folio-org/ui-lists/assets/17111248/d724af5d-5629-41be-bc0a-181fc7dcd4ed">
