### PR TITLE
Fix missing prop for controlled DropdownMenu

### DIFF
--- a/src/components/ActionMenu/ActionMenu.tsx
+++ b/src/components/ActionMenu/ActionMenu.tsx
@@ -35,6 +35,7 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({
     >
       <DropdownMenu
         aria-label="available permissions"
+        open={open}
         onToggle={handleToggle}
       >
         <div className={children ? css.actionMenuGroup : ''}>


### PR DESCRIPTION
See [this Slack thread](https://folio-project.slack.com/archives/C210UCHQ9/p1721214369552029); the `DropdownMenu` component requires either both `open` and `onToggle` props, or neither, depending on if it is controlled or not. Since we are controlling it, we must provide both.

We had not realized this error before due to a bug in the underlying types for stripes-components