### PR TITLE
[UILISTS-152] Add session storage filters

### DIFF
--- a/src/components/ListsTable/ListsTable.tsx
+++ b/src/components/ListsTable/ListsTable.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useEffect } from 'react';
 import { isEqual, noop } from 'lodash';
-import { Loading, MultiColumnList, Row, } from '@folio/stripes/components';
+import { Loading, MultiColumnList, Row } from '@folio/stripes/components';
 
 import { listTableMapping } from './helpers/mappers';
 import { listTableResultFormatter } from './helpers/formatters';
@@ -88,7 +88,6 @@ export const ListsTable: FC<ListsTableProps> = ({
         data-testid="ItemsList"
         contentData={content ?? []}
         headerRowClass={css.listTableHeaderSticky}
-        // @ts-ignore:next-line
         columnWidths={columnWidthsConfig}
         pagingType='prev-next'
         visibleColumns={LISTS_VISIBLE_COLUMNS}

--- a/src/components/ListsTable/ListsTable.tsx
+++ b/src/components/ListsTable/ListsTable.tsx
@@ -88,6 +88,7 @@ export const ListsTable: FC<ListsTableProps> = ({
         data-testid="ItemsList"
         contentData={content ?? []}
         headerRowClass={css.listTableHeaderSticky}
+        // @ts-ignore:next-line
         columnWidths={columnWidthsConfig}
         pagingType='prev-next'
         visibleColumns={LISTS_VISIBLE_COLUMNS}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -14,4 +14,4 @@ export { useVisibleColumns } from './useVisibleColumns';
 export { useCreateList } from './useCreateList';
 export { useRecordTypeLabel } from './useRecordTypeLabel';
 export { useListsPagination } from './useListsPagination';
-
+export { useSessionStorage } from './useSessionStorage';

--- a/src/hooks/useSessionStorage/index.ts
+++ b/src/hooks/useSessionStorage/index.ts
@@ -1,0 +1,1 @@
+export { useSessionStorage } from './useSessionStorage';

--- a/src/hooks/useSessionStorage/useSessionStorage.ts
+++ b/src/hooks/useSessionStorage/useSessionStorage.ts
@@ -1,0 +1,31 @@
+export const useSessionStorage = <T>(key: string) => {
+  const getItem = (): (T | null) => {
+    try {
+      return JSON.parse(sessionStorage.getItem(key) || '');
+    } catch (e) {
+      return null;
+    }
+  };
+
+  const setItem = (value: T) => {
+    try {
+      return sessionStorage.setItem(key, JSON.stringify(value));
+    } catch (e) {
+      return null
+    }
+  };
+
+  const removeItem = () => {
+    try {
+      return sessionStorage.removeItem(key);
+    } catch (e) {
+      return null
+    }
+  };
+
+  return {
+    getItem,
+    setItem,
+    removeItem
+  }
+}

--- a/src/hooks/useSessionStorage/useSessionStorage.ts
+++ b/src/hooks/useSessionStorage/useSessionStorage.ts
@@ -1,7 +1,7 @@
 export const useSessionStorage = <T>(key: string) => {
   const getItem = (): (T | null) => {
     try {
-      return JSON.parse(sessionStorage.getItem(key) || '');
+      return JSON.parse(sessionStorage.getItem(key) ?? '');
     } catch (e) {
       return null;
     }

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -54,4 +54,14 @@ describe('Lists app entry point', () => {
       ).not.toBeInTheDocument();
     });
   });
+
+  it('is expected to clean storage on LOGIN', () => {
+    sessionStorage.setItem('test', '123');
+
+    expect(sessionStorage.getItem('test')).toEqual('123')
+
+    ListsApp.eventHandler('LOGIN')
+
+    expect(sessionStorage.getItem('test')).toBeFalsy();
+  })
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,6 @@
-import React, { FC } from 'react';
+import React from 'react';
 import { Switch, Route } from 'react-router-dom';
-import { IfPermission } from '@folio/stripes/core';
+import { IfPermission, coreEvents } from '@folio/stripes/core';
 
 import {
   CopyListPage,
@@ -13,13 +13,17 @@ import {
 import { useRecordTypes } from './hooks';
 import { USER_PERMS } from './utils/constants';
 
-interface IListsApp {
+interface ListsAppProps {
   match: {
     path: string
   };
 }
 
-export const ListsApp: FC<IListsApp> = (props) => {
+type IListsApp = React.FunctionComponent<ListsAppProps> & {
+  eventHandler: (event: string) => void
+}
+
+export const ListsApp:IListsApp = (props) => {
   const { match: { path } } = props;
 
   const { recordTypes, isLoading } = useRecordTypes();
@@ -77,6 +81,12 @@ export const ListsApp: FC<IListsApp> = (props) => {
       />
     </Switch>
   );
+};
+
+ListsApp.eventHandler = (event: any) => {
+  if (event === coreEvents.LOGIN) {
+    sessionStorage.clear()
+  }
 };
 
 export default ListsApp;

--- a/src/pages/lists/hooks/useFilters/useFilters.ts
+++ b/src/pages/lists/hooks/useFilters/useFilters.ts
@@ -1,8 +1,10 @@
-import { ChangeEvent } from 'react';
+import { ChangeEvent, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import { isEqual } from 'lodash';
 import { buildFiltersObject } from './helpers';
+import { useSessionStorage } from '../../../../hooks'
 import { DEFAULT_FILTERS } from './configurations';
+import { useNamespace } from '@folio/stripes/core';
 
 const FILTERS_URL_KEY = 'filters';
 
@@ -10,14 +12,37 @@ const useURLFilters = () => {
   const history = useHistory();
   const { location } = history;
   const searchParams = new URLSearchParams(location.search)
+  const [namespace] = useNamespace();
+
+  const { getItem, setItem } = useSessionStorage(`${namespace}/filters`)
+
+  useEffect(() => {
+    const filtersURL = (searchParams.get(FILTERS_URL_KEY)?.split(',') || []).filter((filter) => {
+      return !!filter
+    }).join(',');
+
+    const sessionFilters = getItem() as string;
+
+    if (filtersURL) {
+      setItem(filtersURL)
+    }
+
+    if (!filtersURL && sessionFilters) {
+      history.push(`${history.location.pathname}?${FILTERS_URL_KEY}=${sessionFilters}`)
+    }
+  }, [])
+
   const filters = (searchParams.get(FILTERS_URL_KEY)?.split(',') || []).filter((filter) => {
     return !!filter
   });
+
 
   const setValues = (filters: string[]) => {
     searchParams.set(FILTERS_URL_KEY, filters.join(','))
 
     history.push(`${history.location.pathname}?${searchParams.toString()}`)
+
+    setItem(filters.join(','))
   };
 
   return {

--- a/src/pages/lists/hooks/useFilters/useFilters.ts
+++ b/src/pages/lists/hooks/useFilters/useFilters.ts
@@ -30,6 +30,7 @@ const useURLFilters = () => {
     if (!filtersURL && sessionFilters) {
       history.push(`${history.location.pathname}?${FILTERS_URL_KEY}=${sessionFilters}`)
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const filters = (searchParams.get(FILTERS_URL_KEY)?.split(',') || []).filter((filter) => {

--- a/test/jest/__mock__/stripesCore.mock.js
+++ b/test/jest/__mock__/stripesCore.mock.js
@@ -12,6 +12,13 @@ jest.mock('@folio/stripes/core', () => {
     IfPermission: jest.fn(({ perm, children }) => {
       return perm === 'permission' ? children : null;
     }),
+    coreEvents: {
+      LOGIN: 'LOGIN',
+      LOGOUT: 'LOGOUT',
+      SELECT_MODULE: 'SELECT_MODULE',
+      CHANGE_SERVICE_POINT: 'CHANGE_SERVICE_POINT',
+      ERROR: 'ERROR',
+    },
     Pluggable: jest.fn(({ children }) => [children]),
     TitleManager: jest.fn(({ children }) => <>{children}</>),
     AppIcon: jest.fn((props) => (

--- a/test/jest/__mock__/stripesCore.mock.js
+++ b/test/jest/__mock__/stripesCore.mock.js
@@ -28,6 +28,7 @@ jest.mock('@folio/stripes/core', () => {
     useOkapiKy: () => kyMock,
     useStripes: () => ({
       hasPerm: jest.fn().mockReturnValue(true)
-    })
+    }),
+    useNamespace: (string) => `${string}-test-space`,
   };
 });


### PR DESCRIPTION
Implementation of [UILISTS-152](https://folio-org.atlassian.net/browse/UILISTS-152)

Added logic to keep selected filters on sessionStorage and clean sessionStorage on LOGIN event

Demo record: 
https://github.com/user-attachments/assets/9ea0351b-d667-435b-8060-8c10ad2986b2

