### PR TITLE
[UILISTS-152] Add additional check for empty filters state inside list table

### DIFF
--- a/src/components/ListsTable/ListsTable.tsx
+++ b/src/components/ListsTable/ListsTable.tsx
@@ -29,10 +29,10 @@ export const ListsTable: FC<ListsTableProps> = ({
   } = useListsPagination({});
   const { updatedListsData, setRecordIds } = useListsIdsToTrack();
 
-  const prevActiveFilters = usePrevious(activeFilters);
+  const prevActiveFilters: string[] = usePrevious(activeFilters) || [];
 
   useEffect(() => {
-    if (prevActiveFilters && !isEqual(prevActiveFilters, activeFilters)) {
+    if (!prevActiveFilters?.length && !activeFilters.length && !isEqual(prevActiveFilters, activeFilters)) {
       gotToFirstPage();
       setRecordIds([]);
     }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -7,7 +7,6 @@ export const VISIBILITY_SHARED = 'visibility.Shared';
 export const PAGINATION_AMOUNT = 100;
 
 export const FILTER_PANE_VISIBILITY_KEY = '@folio/lists/listsFilterPaneVisibility';
-export const APPLIED_FILTERS_KEY = '@folio/lists/listsAppliedFilters';
 export const CURRENT_PAGE_OFFSET_KEY = '@folio/lists/currentPageOffset';
 
 export const enum USER_PERMS {


### PR DESCRIPTION
[UILISTS-152](https://folio-org.atlassian.net/browse/UILISTS-152)

The list table needs to be refactored in the scope of [UILISTS-156](https://folio-org.atlassian.net/browse/UILISTS-156), and logic of tracking items should be moved in a different place and rewritten

Demo of the bug: 
https://github.com/user-attachments/assets/5946ba64-9885-4eb5-95b5-098efde74f27

Demo of the fix: 
https://github.com/user-attachments/assets/ac787e3d-04b3-4a5e-811a-caf739129efa

