### PR TITLE
[UILISTS-137] Fix shortcuts translation

### DIFF
--- a/src/keyboard-shortcuts.tsx
+++ b/src/keyboard-shortcuts.tsx
@@ -10,12 +10,12 @@ const shortcutItem = (labelKey: string, shortcut: string) => {
 };
 
 export const commandsGeneral = [
-  shortcutItem('commands-label.create', 'Option + n'),
-  shortcutItem('commands-label.edit', 'Cmd + Option + e'),
-  shortcutItem('commands-label.save', 'Cmd + s'),
-  shortcutItem('commands-label.duplicate', 'Option + C'),
+  shortcutItem('commands-label.create', 'Alt + n'),
+  shortcutItem('commands-label.edit', 'Mod + Alt + e'),
+  shortcutItem('commands-label.save', 'Mod + s'),
+  shortcutItem('commands-label.duplicate', 'Alt + C'),
   shortcutItem('commands-label.toggle-lists-detail-accordion', 'spacebar'),
-  shortcutItem('commands-label.expand-list-detail-accordions', 'Cmd  + Option + b'),
-  shortcutItem('commands-label.collapse-list-detail-accordions', 'Cmd  + Option + g'),
-  shortcutItem('commands-label.go-to-filter-pane', 'Cmd + s'),
+  shortcutItem('commands-label.expand-list-detail-accordions', 'Mod + Alt + b'),
+  shortcutItem('commands-label.collapse-list-detail-accordions', 'Mod + Alt + g'),
+  shortcutItem('commands-label.go-to-filter-pane', 'Mod + s'),
 ];


### PR DESCRIPTION
Fix for [UILISTS-137](https://folio-org.atlassian.net/browse/UILISTS-137)

Initially, a logic of replacing keys for Mac and Windows was understood incorrectly in the result; instead of Cmd and Ctrl, should use Mod, and instead of Option, just Alt

Now, replacing work correctly 
How it looks in code: 
<img width="853" alt="Screenshot 2024-08-02 at 19 04 17" src="https://github.com/user-attachments/assets/a1d3ca28-d4d2-41db-895c-156d404da934">

How it looks in the App:
<img width="786" alt="Screenshot 2024-08-02 at 19 03 32" src="https://github.com/user-attachments/assets/dd716fb9-d6b5-4644-b9c2-13a95befa713">
