### PR TITLE
[UILISTS-152] Fix logic of gotToFirstPage method for ListTable

### DIFF
--- a/src/components/ListsTable/ListsTable.tsx
+++ b/src/components/ListsTable/ListsTable.tsx
@@ -32,7 +32,7 @@ export const ListsTable: FC<ListsTableProps> = ({
   const prevActiveFilters: string[] = usePrevious(activeFilters) || [];
 
   useEffect(() => {
-    if (!prevActiveFilters?.length && !activeFilters.length && !isEqual(prevActiveFilters, activeFilters)) {
+    if (prevActiveFilters && !isEqual(prevActiveFilters, activeFilters)) {
       gotToFirstPage();
       setRecordIds([]);
     }

--- a/src/hooks/useListsPagination/useListsPagination.test.ts
+++ b/src/hooks/useListsPagination/useListsPagination.test.ts
@@ -101,8 +101,11 @@ describe('useListsPagination', () => {
   });
 
   describe('goToFirstPage', () => {
-    it('it is expected to call changePage with offset 0', () => {
+    it('it is expected to call changePage with offset 0 if offset more then 0', () => {
       const { result } = renderHook(() => useListsPagination({}));
+      act(() => {
+        result.current.goToLastPage()
+      })
 
       act(() => {
         result.current.gotToFirstPage()

--- a/src/hooks/useListsPagination/useListsPagination.ts
+++ b/src/hooks/useListsPagination/useListsPagination.ts
@@ -34,7 +34,9 @@ export const useListsPagination = ({limit = PAGINATION_AMOUNT}: {limit?: number}
   };
 
   const gotToFirstPage = () => {
-    changePage({ offset: 0 });
+    if (pagination.offset !== 0) {
+      changePage({ offset: 0 });
+    }
   }
 
   const onNeedMoreData = (direction: string) => {


### PR DESCRIPTION
Fix for [UILISTS-152](https://folio-org.atlassian.net/browse/UILISTS-152)

The previous version of the fix led to unexpected behavior when we received 0 filter results.

Here, we prevent rerendering through additional checks using the gotToFirstPage method. 

Fix demo: 
https://github.com/user-attachments/assets/1a1c2180-5904-434e-9620-01dc25dd4e7d

