### PR TITLE
[UILISTS-137] Fix typo in Go to Lists Filter pane shortcut

### DIFF
--- a/src/keyboard-shortcuts.tsx
+++ b/src/keyboard-shortcuts.tsx
@@ -17,5 +17,5 @@ export const commandsGeneral = [
   shortcutItem('commands-label.toggle-lists-detail-accordion', 'spacebar'),
   shortcutItem('commands-label.expand-list-detail-accordions', 'Mod + Alt + b'),
   shortcutItem('commands-label.collapse-list-detail-accordions', 'Mod + Alt + g'),
-  shortcutItem('commands-label.go-to-filter-pane', 'Mod + s'),
+  shortcutItem('commands-label.go-to-filter-pane', 'Mod + Alt + h'),
 ];

--- a/src/keyboard-shortcuts.tsx
+++ b/src/keyboard-shortcuts.tsx
@@ -18,4 +18,5 @@ export const commandsGeneral = [
   shortcutItem('commands-label.expand-list-detail-accordions', 'Mod + Alt + b'),
   shortcutItem('commands-label.collapse-list-detail-accordions', 'Mod + Alt + g'),
   shortcutItem('commands-label.go-to-filter-pane', 'Mod + Alt + h'),
+  shortcutItem('commands-label.open-shortcuts-modal', 'Mod + Alt + k'),
 ];

--- a/translations/ui-lists/en.json
+++ b/translations/ui-lists/en.json
@@ -181,6 +181,7 @@
   "commands-label.collapse-list-detail-accordions": "Collapse all List detail accordions",
   "commands-label.go-to-filter-pane": "Go to Lists Filter pane",
   "commands-label.close-modal-pop-up": "Close a modal or pop-up",
+  "commands-label.open-shortcuts-modal": "Open keyboard shortcuts modal",
   "commands-label.copy": "Copy",
   "commands-label.cut": "Cut",
   "commands-label.paste": "Paste",


### PR DESCRIPTION
Addition for [UILISTS-137](https://folio-org.atlassian.net/browse/UILISTS-137)
<img width="759" alt="Screenshot 2024-08-02 at 23 17 44" src="https://github.com/user-attachments/assets/0b0d2628-4e7b-408d-b3c1-a8e795a2da8a">
