### PR TITLE
[UILISTS-145] Add multiselect record types filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## In progress
 * Lists app - Modal: Shortcut Keys List [UILISTS-137]
+* Results List: Update Record type filter display [UILISTS-145]
 
 [UILISTS-137] https://folio-org.atlassian.net/browse/UILISTS-137
+[UILISTS-145] https://folio-org.atlassian.net/browse/UILISTS-145
 
 ## [3.0.2](https://github.com/folio-org/ui-lists/tree/v3.0.2) (2024-08-07)
 * Fix type issue with `<DropdownMenu>` [UILISTS-168]

--- a/src/components/MainListInfoForm/MainListInfoForm.tsx
+++ b/src/components/MainListInfoForm/MainListInfoForm.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, useState, FocusEvent, useCallback } from 'react';
+import React, { ChangeEvent, useState, FocusEvent } from 'react';
 import { useIntl } from 'react-intl';
 import {
   Layout,
@@ -20,6 +20,7 @@ import {
 import { t, tString } from '../../services';
 
 import css from './MainListInfoForm.module.css';
+import {filterByIncludes} from "../../utils";
 
 type MainListInfoFormProps = {
     onValueChange?: (field: {[key: string]: string}) => void;
@@ -60,9 +61,6 @@ export const MainListInfoForm = (
 
   const showInactiveRadioWarning = showInactiveWarning && isStatusChanged && status === STATUS_VALUES.INACTIVE;
   const activeRadioWarning = showInactiveRadioWarning ? t('warning.inactive-status') : '';
-  const filterEntityTypes = useCallback((args: string, options: EntityTypeSelectOption[]) => {
-    return options.filter(option => option.label.toLowerCase().includes(args.toLowerCase()) || '')
-  }, [])
 
   const renderRecordType = () => {
     if(recordTypeLabel) {
@@ -95,7 +93,7 @@ export const MainListInfoForm = (
           <Selection
             required
             value={value}
-            onFilter={filterEntityTypes}
+            onFilter={filterByIncludes}
             name={FIELD_NAMES.RECORD_TYPE}
             dataOptions={recordTypeOptions}
             placeholder={tString(intl, 'create-list.choose-record-type')}

--- a/src/pages/lists/ListPage.tsx
+++ b/src/pages/lists/ListPage.tsx
@@ -12,7 +12,7 @@ import {
   FilterGroups,
   LoadingPane
 } from '@folio/stripes/components';
-
+import { RecordTypesFilter } from './RecordTypesFilter';
 // @ts-ignore:next-line
 import { CollapseFilterPaneButton, ExpandFilterPaneButton } from '@folio/stripes/smart-components';
 import { IfPermission } from '@folio/stripes/core';
@@ -28,9 +28,11 @@ import css from './ListPage.module.css';
 export const ListPage: React.FC = () => {
   const [totalRecords, setTotalRecords] = useState(0);
   const [filterPaneIsVisible, toggleFilterPane] = useLocalStorageToggle(FILTER_PANE_VISIBILITY_KEY, true);
-  const { filterConfig, isLoadingConfigData } = useFilterConfig();
+  const { filterConfig, isLoadingConfigData, recordTypeConfig } = useFilterConfig();
   const {
     onChangeFilter,
+    onChangRecordType,
+    selectedRecordTypes,
     onResetAll,
     onClearGroup,
     filterCount,
@@ -42,6 +44,7 @@ export const ListPage: React.FC = () => {
   useListsFetchedSinceTimestamp();
 
   if (isLoadingConfigData) return <LoadingPane />;
+
 
   return (
     <Paneset data-test-root-pane>
@@ -74,6 +77,12 @@ export const ListPage: React.FC = () => {
             onChangeFilter={onChangeFilter}
             onClearFilter={onClearGroup}
           />
+          <RecordTypesFilter
+            recordTypeConfig={recordTypeConfig}
+            onChange={onChangRecordType}
+            onClear={onClearGroup}
+            selectedRecordTypes={selectedRecordTypes}
+            />
         </Pane>
       }
       <Pane

--- a/src/pages/lists/RecordTypesFilter/RecordTypesFilter.tsx
+++ b/src/pages/lists/RecordTypesFilter/RecordTypesFilter.tsx
@@ -1,0 +1,57 @@
+import React, { FC } from 'react';
+import {
+  Accordion,
+  FilterAccordionHeader
+} from '@folio/stripes/components';
+import { MultiSelectionFilter } from '@folio/stripes/smart-components';
+import { RECORD_TYPES_FILTER_KEY } from '../constants';
+import { EntityTypeSelectOption } from "../../../interfaces";
+
+type RecordTypesFilterProps = {
+  selectedRecordTypes: string[],
+  recordTypeConfig: {
+    label: React.ReactNode,
+    name: string,
+    values: {
+      value: string,
+      label: string
+    }[]
+  },
+  onChange: (selectedTypes: string[]) => void,
+  onClear: (group: string) => void
+}
+
+export const RecordTypesFilter: FC<RecordTypesFilterProps> = ({
+    selectedRecordTypes,
+    recordTypeConfig,
+    onChange,
+    onClear
+  }) => {
+  const filterEntityTypes = (a = '', options: EntityTypeSelectOption[]) => {
+    return {
+      renderedItems: options.filter(option => option.label.toLowerCase().includes(a.toLowerCase()) || '')
+    }
+  };
+
+  return (
+    <Accordion
+      label={recordTypeConfig.label}
+      separator={false}
+      // @ts-ignore
+      header={FilterAccordionHeader}
+      displayClearButton={selectedRecordTypes.length > 0}
+      onClearFilter={() => onClear(RECORD_TYPES_FILTER_KEY)}
+    >
+      <MultiSelectionFilter
+        // @ts-ignore
+        filter={filterEntityTypes}
+        name={RECORD_TYPES_FILTER_KEY}
+        dataOptions={recordTypeConfig.values}
+        onChange={({values}) => {
+          onChange(values)
+        }}
+        selectedValues={selectedRecordTypes}
+      />
+    </Accordion>
+  )
+};

--- a/src/pages/lists/RecordTypesFilter/RecordTypesFilter.tsx
+++ b/src/pages/lists/RecordTypesFilter/RecordTypesFilter.tsx
@@ -5,7 +5,7 @@ import {
 } from '@folio/stripes/components';
 import { MultiSelectionFilter } from '@folio/stripes/smart-components';
 import { RECORD_TYPES_FILTER_KEY } from '../constants';
-import { EntityTypeSelectOption } from "../../../interfaces";
+import { filterByIncludes } from '../../../utils';
 
 type RecordTypesFilterProps = {
   selectedRecordTypes: string[],
@@ -27,11 +27,7 @@ export const RecordTypesFilter: FC<RecordTypesFilterProps> = ({
     onChange,
     onClear
   }) => {
-  const filterEntityTypes = (a = '', options: EntityTypeSelectOption[]) => {
-    return {
-      renderedItems: options.filter(option => option.label.toLowerCase().includes(a.toLowerCase()) || '')
-    }
-  };
+
 
   return (
     <Accordion
@@ -44,7 +40,7 @@ export const RecordTypesFilter: FC<RecordTypesFilterProps> = ({
     >
       <MultiSelectionFilter
         // @ts-ignore
-        filter={filterEntityTypes}
+        filter={filterByIncludes}
         name={RECORD_TYPES_FILTER_KEY}
         dataOptions={recordTypeConfig.values}
         onChange={({values}) => {

--- a/src/pages/lists/RecordTypesFilter/RecordTypesFilter.tsx
+++ b/src/pages/lists/RecordTypesFilter/RecordTypesFilter.tsx
@@ -5,7 +5,7 @@ import {
 } from '@folio/stripes/components';
 import { MultiSelectionFilter } from '@folio/stripes/smart-components';
 import { RECORD_TYPES_FILTER_KEY } from '../constants';
-import { filterByIncludes } from '../../../utils';
+import { filterEntityTypes } from './helpers';
 
 type RecordTypesFilterProps = {
   selectedRecordTypes: string[],
@@ -40,7 +40,7 @@ export const RecordTypesFilter: FC<RecordTypesFilterProps> = ({
     >
       <MultiSelectionFilter
         // @ts-ignore
-        filter={filterByIncludes}
+        filter={filterEntityTypes}
         name={RECORD_TYPES_FILTER_KEY}
         dataOptions={recordTypeConfig.values}
         onChange={({values}) => {

--- a/src/pages/lists/RecordTypesFilter/RecordTypesFilters.test.tsx
+++ b/src/pages/lists/RecordTypesFilter/RecordTypesFilters.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { RecordTypesFilter } from './RecordTypesFilter';
+import { render } from '@testing-library/react';
+import user from '@testing-library/user-event';
+import { screen } from '@testing-library/dom';
+
+
+
+const onChange = jest.fn();
+const onClear = jest.fn();
+
+const defaultConfig = {
+  label: 'Record filter',
+  name: 'record_types',
+  values: [
+    {
+      label: 'Holdings',
+      value: 'record_types.123213123'
+    },
+    {
+      label: 'Loans',
+      value: 'record_types.12asdsa3213123'
+    }
+  ]
+}
+
+const renderRecordTypesFilter = ({config = defaultConfig, selected = []}: any) => {
+  return render(
+    <RecordTypesFilter
+      recordTypeConfig={config}
+      onChange={onChange}
+      onClear={onClear}
+      selectedRecordTypes={selected}
+    />
+  );
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+})
+
+describe('RecordTypesFilter', () => {
+  describe('Clean', () => {
+    it('is expected to render clean button', async () => {
+      renderRecordTypesFilter({selected:['Loans']})
+
+      const button = screen.getByRole('button', { name: /clean/i })
+
+      await user.click(button)
+
+      expect(onClear).toBeCalledWith("record_types")
+    });
+  });
+  describe('onChange', () => {
+    it('is expected to render clean button', async () => {
+      renderRecordTypesFilter({selected:['Loans']})
+
+      const button = screen.getByRole('button', { name: /change/i })
+
+      await user.click(button)
+
+      expect(onChange).toBeCalled()
+    });
+  })
+})

--- a/src/pages/lists/RecordTypesFilter/helpers.test.ts
+++ b/src/pages/lists/RecordTypesFilter/helpers.test.ts
@@ -1,0 +1,27 @@
+import {expect} from "@jest/globals";
+import {filterEntityTypes} from "./helpers";
+
+
+describe('filterEntitytypes', () => {
+  it('is expected to filter entity types options', () => {
+    const items = [{
+      label: 'Loans',
+      value: '1233131',
+      selected: false
+      },
+      {
+        label: 'Users',
+        value: '123s1233131',
+        selected: false
+      }];
+
+
+    expect(filterEntityTypes('sers', items)).toEqual({
+      renderedItems: [{
+        label: 'Users',
+        value: '123s1233131',
+        selected: false
+      }]
+    })
+  })
+})

--- a/src/pages/lists/RecordTypesFilter/helpers.ts
+++ b/src/pages/lists/RecordTypesFilter/helpers.ts
@@ -1,0 +1,8 @@
+import {EntityTypeSelectOption} from "../../../interfaces";
+import {filterByIncludes} from "../../../utils";
+
+export const filterEntityTypes = (term: string, options: EntityTypeSelectOption[]) => {
+  return {
+    renderedItems: filterByIncludes(term, options)
+  }
+};

--- a/src/pages/lists/RecordTypesFilter/index.ts
+++ b/src/pages/lists/RecordTypesFilter/index.ts
@@ -1,0 +1,1 @@
+export { RecordTypesFilter } from './RecordTypesFilter'

--- a/src/pages/lists/constants.ts
+++ b/src/pages/lists/constants.ts
@@ -1,0 +1,1 @@
+export const RECORD_TYPES_FILTER_KEY = 'record_types';

--- a/src/pages/lists/hooks/useFilterConfig.ts
+++ b/src/pages/lists/hooks/useFilterConfig.ts
@@ -1,36 +1,39 @@
 import { FilterGroupsConfig } from '@folio/stripes/components';
 import { useRecordTypes } from '../../../hooks';
+import { useIntl } from 'react-intl';
+import { tString} from '../../../services';
+import { RECORD_TYPES_FILTER_KEY } from '../constants';
 
 export default function useFilterConfig() {
   const { recordTypes = [], isLoading } = useRecordTypes();
-
+  const intl = useIntl();
   const filterConfig: FilterGroupsConfig = [
     {
-      label: 'Status',
+      label: tString(intl,'filter-label.status'),
       name: 'status',
       cql: 'status',
       values: ['Active', 'Inactive'],
     },
     {
-      label: 'Visibility',
+      label: tString(intl, 'filter-label.visibility'),
       name: 'visibility',
       cql: 'visibility',
       values: ['Shared', 'Private'],
-    },
-    {
-      label: 'Record types',
-      name: 'record_types',
-      cql: 'record.types',
-      values: recordTypes?.map((item) => ({
-        name: item.id ?? item.label,
-        displayName: item.label,
-        cql: item.id,
-      })),
-    },
+    }
   ];
+
+  const recordTypeConfig = {
+    label: tString(intl,'filter-label.record-types'),
+    name: RECORD_TYPES_FILTER_KEY,
+    values: recordTypes?.map((item) => ({
+      value: `record_types.${item.id ?? item.label}`,
+      label: item.label,
+    })),
+};
 
   return {
     filterConfig,
+    recordTypeConfig,
     isLoadingConfigData: isLoading,
   };
 }

--- a/src/pages/lists/hooks/useFilters/useFilters.ts
+++ b/src/pages/lists/hooks/useFilters/useFilters.ts
@@ -84,8 +84,6 @@ export function useFilters() {
       return !item.startsWith('record_types')
     })
 
-    console.log('onChangRecordType =====>>>>', a);
-
     setValues([...fil, ...a])
   }
 

--- a/src/pages/lists/hooks/useFilters/useFilters.ts
+++ b/src/pages/lists/hooks/useFilters/useFilters.ts
@@ -79,6 +79,16 @@ export function useFilters() {
 
   const filterCount = filterParams?.length;
 
+  const onChangRecordType = (...a: any) => {
+    const fil = filterParams.filter((item: string) => {
+      return !item.startsWith('record_types')
+    })
+
+    console.log('onChangRecordType =====>>>>', a);
+
+    setValues([...fil, ...a])
+  }
+
   const onChangeFilter = (e: ChangeEvent<HTMLInputElement>) => {
     const { checked, name } = e.target;
 
@@ -101,14 +111,20 @@ export function useFilters() {
     setValues(filters);
   };
 
+  const selectedRecordTypes = filterParams.filter(value => {
+    return value.startsWith('record_types')
+  })
+
   const isDefaultState = isEqual(DEFAULT_FILTERS, filterParams);
 
   return {
     onChangeFilter,
+    onChangRecordType,
     onClearGroup,
     onResetAll,
     filterCount,
     activeFilters: filterParams,
+    selectedRecordTypes,
     filtersObject: buildFiltersObject(filterParams),
     isDefaultState
   };

--- a/src/utils/helpers.test.ts
+++ b/src/utils/helpers.test.ts
@@ -1,5 +1,6 @@
-import { buildListsUrl } from './helpers';
+import { buildListsUrl, filterByIncludes } from './helpers';
 import { STATUS_ACTIVE, STATUS_INACTIVE, VISIBILITY_PRIVATE, VISIBILITY_SHARED } from './constants';
+import {expect} from "@jest/globals";
 
 const baseUrl = 'http://www.test.com';
 
@@ -73,4 +74,22 @@ describe('Helpers', () => {
       });
     });
   });
+
+  describe('filterByCinludes', () => {
+    it('is expected to filter items', () => {
+      const items = [{
+        label: 'Loans',
+        value: '1233131'
+      },
+      {
+        label: 'Users',
+        value: '123s1233131'
+      }];
+
+      expect(filterByIncludes('ers', items)).toEqual([{
+        label: 'Users',
+        value: '123s1233131'
+      }])
+    })
+  })
 });

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -66,7 +66,7 @@ export const checkIncludes = (target: string, string: string) => {
   return string.includes(target)
 };
 
-export const filterByIncludes = (term: string = '', options: {label: string, value: string}[]) => {
+export const filterByIncludes = (term: string, options: {label: string, value: string}[]) => {
   return options.filter( option => {
     return checkIncludes(term.toLowerCase(), option.label.toLowerCase());
   });

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -61,3 +61,13 @@ export const createColumnHash = (listColumns: string[]) => {
 }
 
 export const createStorageHashKey = (listID: string): string => `${listID}-hash`
+
+export const checkIncludes = (target: string, string: string) => {
+  return string.includes(target)
+};
+
+export const filterByIncludes = (term: string = '', options: {label: string, value: string}[]) => {
+  return options.filter( option => {
+    return checkIncludes(term.toLowerCase(), option.label.toLowerCase());
+  });
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,5 +2,6 @@ export {
   getVisibleColumnsKey,
   buildListsUrl,
   createColumnHash,
-  createStorageHashKey
+  createStorageHashKey,
+  filterByIncludes
 } from './helpers';

--- a/test/jest/__mock__/stripesComponents.mock.js
+++ b/test/jest/__mock__/stripesComponents.mock.js
@@ -274,7 +274,7 @@ jest.mock('@folio/stripes/components', () => ({
     <div aria-label={contentLabel} {...rest}>{isOpen ? children : ''}</div>
   )),
   Accordion: jest.fn(({ children, ...rest }) => (
-    <span {...rest}>{children}</span>
+      <span {...rest}> {rest.displayClearButton && <button onClick={rest.onClearFilter}>Clean</button>} Accordion {children}</span>
   )),
   AccordionSet: jest.fn(({ children, ...rest }) => (
     <span {...rest}>{children}</span>

--- a/test/jest/__mock__/stripesSmartComponents.mock.js
+++ b/test/jest/__mock__/stripesSmartComponents.mock.js
@@ -14,5 +14,6 @@ jest.mock('@folio/stripes/smart-components', () => ({
       ))}
     </div>
   )),
+  MultiSelectionFilter:  jest.fn(() => <div>MultiSelectionFilter</div>),
   CollapseFilterPaneButton: jest.fn(({ onClick }) => <div onClick={onClick} />)
 }));

--- a/test/jest/__mock__/stripesSmartComponents.mock.js
+++ b/test/jest/__mock__/stripesSmartComponents.mock.js
@@ -14,6 +14,13 @@ jest.mock('@folio/stripes/smart-components', () => ({
       ))}
     </div>
   )),
-  MultiSelectionFilter:  jest.fn(() => <div>MultiSelectionFilter</div>),
+  MultiSelectionFilter:  jest.fn(({onChange, onClear, selectedRecordTypes}) => (
+      <>
+        <div>MultiSelectionFilter</div>
+        <button onClick={onChange}>
+            onChange
+        </button>
+      </>
+  )),
   CollapseFilterPaneButton: jest.fn(({ onClick }) => <div onClick={onClick} />)
 }));

--- a/translations/ui-lists/en.json
+++ b/translations/ui-lists/en.json
@@ -172,6 +172,10 @@
 
   "app-menu.keyboard-shortcuts": "Keyboard shortcuts",
 
+  "filter-label.record-types": "Record types",
+  "filter-label.status": "Status",
+  "filter-label.visibility": "Visibility",
+
   "commands-label.create": "Create a new list",
   "commands-label.edit": "Edit a list",
   "commands-label.save": "Save a list" ,


### PR DESCRIPTION
Implementation of [UILISTS-145](https://folio-org.atlassian.net/browse/UILISTS-145)
Multiselect record type filter for list page 
<img width="323" alt="Screenshot 2024-08-13 at 15 53 58" src="https://github.com/user-attachments/assets/572ad8aa-33d1-4982-a318-4df2dcf99ea9">

Demo record:
https://github.com/user-attachments/assets/bc22e3d8-6799-4602-ab32-67615710d469

