### PR TITLE
[UILISTS-157] Support export of visible columns and export of all columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 * Lists app - Modal: Shortcut Keys List [UILISTS-137]
 * Results List: Update Record type filter display [UILISTS-145]
 * Move stripes-testing in dev dependencies [UILISTS-138]
+* Support export of visible columns and export of all columns [UILISTS-157]
 
+[UILISTS-157] https://folio-org.atlassian.net/browse/UILISTS-157
 [UILISTS-138] https://folio-org.atlassian.net/browse/UILISTS-138
 [UILISTS-137] https://folio-org.atlassian.net/browse/UILISTS-137
 [UILISTS-145] https://folio-org.atlassian.net/browse/UILISTS-145

--- a/src/components/EditListResultViewer/EditListResultViewer.tsx
+++ b/src/components/EditListResultViewer/EditListResultViewer.tsx
@@ -2,7 +2,7 @@
 import { Pluggable, useOkapiKy } from '@folio/stripes/core';
 import React, { FC } from 'react';
 import { useVisibleColumns } from '../../hooks';
-import {QueryBuilderColumnMetadata, STATUS_VALUES, VISIBILITY_VALUES} from '../../interfaces';
+import { QueryBuilderColumnMetadata, STATUS_VALUES, VISIBILITY_VALUES } from '../../interfaces';
 import { t } from '../../services';
 import { ConfigureQuery } from '../ConfigureQuery';
 

--- a/src/components/EditListResultViewer/EditListResultViewer.tsx
+++ b/src/components/EditListResultViewer/EditListResultViewer.tsx
@@ -2,7 +2,7 @@
 import { Pluggable, useOkapiKy } from '@folio/stripes/core';
 import React, { FC } from 'react';
 import { useVisibleColumns } from '../../hooks';
-import { STATUS_VALUES, VISIBILITY_VALUES } from '../../interfaces';
+import {QueryBuilderColumnMetadata, STATUS_VALUES, VISIBILITY_VALUES} from '../../interfaces';
 import { t } from '../../services';
 import { ConfigureQuery } from '../ConfigureQuery';
 
@@ -22,6 +22,7 @@ interface EditListResultViewerProps {
   description: string,
   isDuplicating?: boolean,
   isQueryButtonDisabled?: boolean,
+  setColumns?: (columns: QueryBuilderColumnMetadata[]) => void;
 }
 
 export const EditListResultViewer:FC<EditListResultViewerProps> = (
@@ -37,6 +38,7 @@ export const EditListResultViewer:FC<EditListResultViewerProps> = (
     visibility,
     description,
     fields,
+    setColumns,
     isDuplicating = false,
     isQueryButtonDisabled = false
   }
@@ -69,7 +71,7 @@ export const EditListResultViewer:FC<EditListResultViewerProps> = (
       contentDataSource={getAsyncContentData}
       entityTypeDataSource={getAsyncEntityType}
       visibleColumns={visibleColumns}
-      onSetDefaultColumns={() => {}}
+      onSetDefaultColumns={setColumns}
       contentQueryKeys={visibleColumns}
       height={500}
       additionalControls={(

--- a/src/components/ListAppIcon/ListAppIcon.test.tsx
+++ b/src/components/ListAppIcon/ListAppIcon.test.tsx
@@ -4,7 +4,7 @@ import { screen } from '@testing-library/dom';
 
 import { ListAppIcon } from './ListAppIcon';
 // @ts-ignore
-import {runAxeTest} from "@folio/stripes-testing";
+import { runAxeTest } from "@folio/stripes-testing";
 
 describe('ListAppIcon', () => {
   beforeEach(() => {

--- a/src/components/ListsTable/ListsTable.test.tsx
+++ b/src/components/ListsTable/ListsTable.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { MemoryRouter } from 'react-router';
 import { QueryClientProvider } from 'react-query';
 // @ts-ignore
-import {runAxeTest} from "@folio/stripes-testing";
+import { runAxeTest } from "@folio/stripes-testing";
 import { Server } from 'miragejs';
 import { render } from '@testing-library/react';
 import { screen, waitFor } from '@testing-library/dom';

--- a/src/hooks/useCSVListExport/useCSVExport.tsx
+++ b/src/hooks/useCSVListExport/useCSVExport.tsx
@@ -32,7 +32,6 @@ export const useCSVExport = ({ listId, listName, listDetails, columns }: { listI
 
   const { isLoading, mutateAsync, data } = useMutation<ListExport, HTTPError, {allColumns?: boolean}>({
     mutationFn: ({allColumns = false}) => {
-      console.log(listDetails);
       const columnsToExport = allColumns ? columns : visibleColumns;
 
       return ky.post(`lists/${listId}/exports`, { json: columnsToExport }).json<ListExport>()

--- a/src/hooks/useCSVListExport/useCSVExport.tsx
+++ b/src/hooks/useCSVListExport/useCSVExport.tsx
@@ -9,7 +9,7 @@ import { useCSVExportCancel } from './useCSVExportCancel';
 import { useCSVExportPolling } from './useCSVExportPolling';
 import { useVisibleColumns } from '../useVisibleColumns';
 
-export const useCSVExport = ({ listId, listName, listDetails }: { listId: string; listName: string, listDetails?: ListsRecordDetails }) => {
+export const useCSVExport = ({ listId, listName, listDetails, columns }: { listId: string; listName: string, listDetails?: ListsRecordDetails, columns?: string[] }) => {
   const { showSuccessMessage, showErrorMessage } = useMessages();
   const ky = useOkapiKy();
   const [values] = useLocalStorage<{ [key: string]: string }>('listIdsToExport', {});
@@ -28,10 +28,15 @@ export const useCSVExport = ({ listId, listName, listDetails }: { listId: string
     removeListFromStorage();
   });
 
-  const columnsToExport = useVisibleColumns(listId).visibleColumns ?? listDetails?.fields ?? [];
+  const visibleColumns = useVisibleColumns(listId).visibleColumns ?? listDetails?.fields ?? [];
 
-  const { isLoading, mutateAsync, data } = useMutation<ListExport, HTTPError>({
-    mutationFn: () => ky.post(`lists/${listId}/exports`, { json: columnsToExport }).json<ListExport>(),
+  const { isLoading, mutateAsync, data } = useMutation<ListExport, HTTPError, {allColumns?: boolean}>({
+    mutationFn: ({allColumns = false}) => {
+      console.log(listDetails);
+      const columnsToExport = allColumns ? columns : visibleColumns;
+
+      return ky.post(`lists/${listId}/exports`, { json: columnsToExport }).json<ListExport>()
+    },
     onSuccess: async ({ exportId }) => {
       showSuccessMessage({
         message: t('callout.list.csv-export.begin', {

--- a/src/pages/copylist/CopyListPage.test.tsx
+++ b/src/pages/copylist/CopyListPage.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { MemoryRouter } from 'react-router';
 import { QueryClientProvider } from 'react-query';
 // @ts-ignore
-import {runAxeTest} from "@folio/stripes-testing";
+import { runAxeTest } from "@folio/stripes-testing";
 import { screen, waitFor } from '@testing-library/dom';
 import user from '@testing-library/user-event';
 import { render } from '@testing-library/react';

--- a/src/pages/createlist/CreateListPage.test.tsx
+++ b/src/pages/createlist/CreateListPage.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { MemoryRouter } from 'react-router';
 import { QueryClientProvider } from 'react-query';
 // @ts-ignore
-import {runAxeTest} from "@folio/stripes-testing";
+import { runAxeTest } from "@folio/stripes-testing";
 import { screen, waitFor, within } from '@testing-library/dom';
 import user from '@testing-library/user-event';
 import { render } from '@testing-library/react';

--- a/src/pages/editlist/EditListPage.tsx
+++ b/src/pages/editlist/EditListPage.tsx
@@ -24,7 +24,7 @@ import {
 import { EditListMenu } from './components';
 import { useEditListFormState, useEditList } from './hooks';
 
-import { FIELD_NAMES } from '../../interfaces';
+import {FIELD_NAMES, QueryBuilderColumnMetadata} from '../../interfaces';
 import { HOME_PAGE_URL } from '../../constants';
 
 
@@ -33,6 +33,8 @@ export const EditListPage:FC = () => {
   const intl = useIntl();
   const stripes = useStripes();
   const { id }: { id: string } = useParams();
+  const [columns, setColumns] = useState<QueryBuilderColumnMetadata[]>([]);
+
   const { data: listDetails, isLoading: loadingListDetails, detailsError } = useListDetails(id);
 
   const listName = listDetails?.name ?? '';
@@ -41,7 +43,12 @@ export const EditListPage:FC = () => {
 
   const { showSuccessMessage, showErrorMessage } = useMessages();
   const { state, hasChanges, onValueChange, isListBecameActive } = useEditListFormState(listDetails, loadingListDetails);
-  const { requestExport, isExportInProgress, cancelExport, isCancelExportInProgress } = useCSVExport({ listId: id, listName, listDetails });
+  const { requestExport, isExportInProgress, cancelExport, isCancelExportInProgress } = useCSVExport({
+    listId: id,
+    listName,
+    listDetails,
+    columns: columns.map(({value}) => value)
+  });
   const { deleteList, isDeleteInProgress } = useDeleteList(({ id,
     onSuccess: () => {
       showSuccessMessage({
@@ -127,7 +134,8 @@ export const EditListPage:FC = () => {
 
   const buttonHandlers = {
     'delete': () => setShowConfirmDeleteModal(true),
-    'export': () => requestExport(),
+    'export-all': () => requestExport({}),
+    'export-visible': () => requestExport({allColumns: true}),
     'cancel-export': () => cancelExport(),
   };
 
@@ -205,6 +213,7 @@ export const EditListPage:FC = () => {
           listName={state[FIELD_NAMES.LIST_NAME]}
           visibility={state[FIELD_NAMES.VISIBILITY]}
           description={state[FIELD_NAMES.DESCRIPTION]}
+          setColumns={setColumns}
         />
         <CancelEditModal
           onCancel={() => {

--- a/src/pages/editlist/components/EditListMenu/EditListMenu.test.tsx
+++ b/src/pages/editlist/components/EditListMenu/EditListMenu.test.tsx
@@ -13,7 +13,8 @@ describe('EditListMenu', () => {
 
   const mockButtonHandlers = {
     'delete': jest.fn(),
-    'export': jest.fn(),
+    'export-all': jest.fn(),
+    'export-visible': jest.fn(),
     'cancel-export': jest.fn(),
   };
 
@@ -26,10 +27,14 @@ describe('EditListMenu', () => {
     render(<EditListMenu buttonHandlers={mockButtonHandlers} conditions={mockConditions} stripes={stripes} />);
 
     const deleteButton = screen.getByText('ui-lists.pane.dropdown.delete');
-    const exportButton = screen.getByText('ui-lists.pane.dropdown.export');
+    const exportButton = screen.getByText('ui-lists.pane.dropdown.export-all');
+    const exportVisibleButton = screen.getByText('ui-lists.pane.dropdown.export-visible');
 
+      screen.logTestingPlaygroundURL()
     expect(deleteButton).toBeInTheDocument();
     expect(exportButton).toBeInTheDocument();
+    expect(exportVisibleButton).toBeInTheDocument();
+
   });
 
   it('should call delete handler when delete button is clicked', async () => {
@@ -44,10 +49,10 @@ describe('EditListMenu', () => {
   it('should call export handler when export button is clicked', () => {
     render(<EditListMenu buttonHandlers={mockButtonHandlers} conditions={mockConditions} stripes={stripes} />);
 
-    const exportButton = screen.getByText('ui-lists.pane.dropdown.export');
+    const exportButton = screen.getByText('ui-lists.pane.dropdown.export-all');
     fireEvent.click(exportButton);
 
-    expect(mockButtonHandlers.export).toHaveBeenCalled();
+    expect(mockButtonHandlers['export-all']).toHaveBeenCalled();
   });
 
   it('should render cancel export button when export is in progress', () => {

--- a/src/pages/editlist/components/EditListMenu/EditListMenu.tsx
+++ b/src/pages/editlist/components/EditListMenu/EditListMenu.tsx
@@ -31,14 +31,14 @@ export const EditListMenu: React.FC<ListInformationMenuProps> = ({
   const actionButtons:ActionButton[] = [];
 
   const initExportButton = {
-    label: 'export',
+    label: 'export-all',
     icon: ICONS.download,
     onClick: buttonHandlers['export-all'],
     disabled: isExportDisabled(conditions)
   };
 
   const initExportAllButton = {
-    label: 'export',
+    label: 'export-visible',
     icon: ICONS.download,
     onClick: buttonHandlers['export-visible'],
     disabled: isExportDisabled(conditions)

--- a/src/pages/editlist/components/EditListMenu/EditListMenu.tsx
+++ b/src/pages/editlist/components/EditListMenu/EditListMenu.tsx
@@ -13,7 +13,8 @@ import { USER_PERMS } from '../../../../utils/constants';
 interface ListInformationMenuProps {
   buttonHandlers: {
     'delete':() => void,
-    'export': () => void,
+    'export-all': () => void,
+    'export-visible': () => void,
     'cancel-export': () => void
   },
   conditions: DisablingConditions,
@@ -32,7 +33,14 @@ export const EditListMenu: React.FC<ListInformationMenuProps> = ({
   const initExportButton = {
     label: 'export',
     icon: ICONS.download,
-    onClick: buttonHandlers.export,
+    onClick: buttonHandlers['export-all'],
+    disabled: isExportDisabled(conditions)
+  };
+
+  const initExportAllButton = {
+    label: 'export',
+    icon: ICONS.download,
+    onClick: buttonHandlers['export-visible'],
     disabled: isExportDisabled(conditions)
   };
 
@@ -43,7 +51,8 @@ export const EditListMenu: React.FC<ListInformationMenuProps> = ({
     disabled: isCancelExportDisabled(conditions)
   };
 
-  const exportSlot = isExportInProgress ? cancelExportButton : initExportButton;
+  const exportSlot = isExportInProgress ? [cancelExportButton] : [initExportButton, initExportAllButton];
+
   const deleteSlot = {
     label: 'delete',
     icon: ICONS.trash,
@@ -52,7 +61,7 @@ export const EditListMenu: React.FC<ListInformationMenuProps> = ({
   };
 
   if (stripes.hasPerm(USER_PERMS.ExportList)) {
-    actionButtons.push(exportSlot);
+    actionButtons.push(...exportSlot);
   }
 
   if (stripes.hasPerm(USER_PERMS.DeleteList)) {

--- a/src/pages/listInformation/ListInformationPage.test.tsx
+++ b/src/pages/listInformation/ListInformationPage.test.tsx
@@ -226,7 +226,7 @@ describe('ListInformationPage Page', () => {
             jest.spyOn(acq, 'useShowCallout').mockImplementation(() => showMessageMock);
 
             const exportButton = screen.getByRole('menuitem', {
-              name: /ui-lists.pane.dropdown.export/i
+              name: /ui-lists.pane.dropdown.export-visible/i
             });
 
             expect(exportButton).toBeEnabled();
@@ -262,7 +262,7 @@ describe('ListInformationPage Page', () => {
             jest.spyOn(acq, 'useShowCallout').mockImplementation(() => showMessageMock);
 
             const exportButton = screen.getByRole('menuitem', {
-              name: /ui-lists.pane.dropdown.export/i
+              name: /ui-lists.pane.dropdown.export-visible/i
             });
 
             expect(exportButton).toBeEnabled();

--- a/src/pages/listInformation/ListInformationPage.tsx
+++ b/src/pages/listInformation/ListInformationPage.tsx
@@ -50,11 +50,14 @@ export const ListInformationPage: React.FC = () => {
   const { name: listName = '' } = listData ?? {};
   const [refreshTrigger, setRefreshTrigger] = useState(uniqueId());
   const recordTypeLabel = useRecordTypeLabel(listData?.entityTypeId);
+  const [columnControls, setColumnControls] = useState<QueryBuilderColumnMetadata[]>([]);
 
   const { requestExport, isExportInProgress, isCancelExportInProgress, cancelExport } = useCSVExport({
     listId: id,
-    listName
+    listName,
+    columns: columnControls.map(({value}) => value)
   });
+
   const queryClient = useQueryClient();
   const [showSuccessRefreshMessage, setShowSuccessRefreshMessage] = useState(false);
   const [showConfirmDeleteModal, setShowConfirmDeleteModal] = useState(false);
@@ -129,7 +132,6 @@ export const ListInformationPage: React.FC = () => {
   const closeSuccessMessage = () => {
     setShowSuccessRefreshMessage(false);
   };
-  const [columnControls, setColumnControls] = useState<QueryBuilderColumnMetadata[]>([]);
 
   if (detailsError) {
     return <ErrorComponent error={detailsError} />;
@@ -187,7 +189,9 @@ export const ListInformationPage: React.FC = () => {
   }
 
   if (stripes.hasPerm(USER_PERMS.ExportList)) {
-    buttonHandlers.export = () => requestExport();
+    buttonHandlers['export-all'] = () => requestExport({allColumns: true});
+    buttonHandlers['export-visible'] = () => requestExport({});
+
     buttonHandlers['cancel-export'] = () => cancelExport();
   }
 

--- a/src/pages/listInformation/components/ListInformationMenu/ListInformationMenu.test.tsx
+++ b/src/pages/listInformation/components/ListInformationMenu/ListInformationMenu.test.tsx
@@ -14,7 +14,8 @@ const mockProps: ListInformationMenuProps = {
     'edit': jest.fn(),
     'copy': jest.fn(),
     'delete': jest.fn(),
-    'export': jest.fn(),
+    'export-all': jest.fn(),
+    'export-visible': jest.fn(),
     'cancel-export': jest.fn()
   },
   conditions: { isListCanned: false },
@@ -49,9 +50,16 @@ describe('ListInformationMenu', () => {
       expect(link).toBeInTheDocument();
     });
 
-    it('should render Export list link', () => {
+    it('should render Export all list link', () => {
       render(<ListInformationMenu {...mockProps} />);
-      const link = screen.queryByText('ui-lists.pane.dropdown.export');
+      const link = screen.queryByText('ui-lists.pane.dropdown.export-all');
+
+      expect(link).toBeInTheDocument();
+    });
+
+    it('should render Export all list link', () => {
+      render(<ListInformationMenu {...mockProps} />);
+      const link = screen.queryByText('ui-lists.pane.dropdown.export-visible');
 
       expect(link).toBeInTheDocument();
     });

--- a/src/pages/listInformation/components/ListInformationMenu/ListInformationMenu.tsx
+++ b/src/pages/listInformation/components/ListInformationMenu/ListInformationMenu.tsx
@@ -25,7 +25,8 @@ export interface ListInformationMenuProps {
     'refresh': () => void,
     'edit': () => void,
     'delete':() => void,
-    'export': () => void,
+    'export-all': () => void,
+    'export-visible': () => void,
     'cancel-export': () => void,
     'copy': () => void
   },
@@ -57,9 +58,16 @@ export const ListInformationMenu: React.FC<ListInformationMenuProps> = ({
   };
 
   const initExportButton = {
-    label: 'export',
+    label: 'export-visible',
     icon: ICONS.download,
-    onClick: buttonHandlers.export,
+    onClick: buttonHandlers['export-visible'],
+    disabled: isExportDisabled(conditions)
+  };
+
+  const initExportAllButton = {
+    label: 'export-all',
+    icon: ICONS.download,
+    onClick: buttonHandlers['export-all'],
     disabled: isExportDisabled(conditions)
   };
 
@@ -76,7 +84,7 @@ export const ListInformationMenu: React.FC<ListInformationMenuProps> = ({
     refreshButton
   );
 
-  const exportSlot = isExportInProgress ? cancelExportButton : initExportButton;
+  const exportSlot = isExportInProgress ? [cancelExportButton] : [initExportButton, initExportAllButton];
 
   const actionButtons:ActionButton[] = [];
 
@@ -116,7 +124,7 @@ export const ListInformationMenu: React.FC<ListInformationMenuProps> = ({
   }
 
   if (stripes.hasPerm(USER_PERMS.ExportList)) {
-    actionButtons.push(exportSlot);
+    actionButtons.push(...exportSlot);
   }
 
   return (

--- a/src/pages/lists/ListPage.test.tsx
+++ b/src/pages/lists/ListPage.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { MemoryRouter } from 'react-router';
 import { QueryClientProvider } from 'react-query';
 // @ts-ignore
-import {runAxeTest} from "@folio/stripes-testing";
+import { runAxeTest } from "@folio/stripes-testing";
 import { waitFor, screen } from '@testing-library/dom';
 import { render } from '@testing-library/react';
 import { IfPermission } from '@folio/stripes/core';

--- a/translations/ui-lists/en.json
+++ b/translations/ui-lists/en.json
@@ -49,7 +49,8 @@
   "pane.dropdown.delete": "Delete list",
   "pane.dropdown.edit": "Edit list",
   "pane.dropdown.copy": "Duplicate list",
-  "pane.dropdown.export": "Export list (CSV)",
+  "pane.dropdown.export-all": "Export all columns (CSV)",
+  "pane.dropdown.export-visible": "Export visible columns (CSV)",
   "pane.dropdown.cancel-export": "Cancel export",
 
   "status-toast.success.refresh-complete": "<strong>Refresh complete</strong> with <strong>{count}</strong> records: ",


### PR DESCRIPTION
Implementation of [UILISTS-157](https://folio-org.atlassian.net/browse/UILISTS-157)
Added logic to export all existing comms or visible columns.
<img width="316" alt="Screenshot 2024-08-26 at 12 36 38" src="https://github.com/user-attachments/assets/45893827-a37f-4612-98f5-1df65051169a">
