### PR TITLE
[UIPQB-120] Fix Query Builder resetting on RTR refresh

### DIFF
--- a/src/components/EditListResultViewer/EditListResultViewer.tsx
+++ b/src/components/EditListResultViewer/EditListResultViewer.tsx
@@ -1,6 +1,5 @@
-// @ts-ignore
 import { Pluggable, useOkapiKy } from '@folio/stripes/core';
-import React, { FC } from 'react';
+import React, { FC, useCallback, useMemo } from 'react';
 import { useVisibleColumns } from '../../hooks';
 import { QueryBuilderColumnMetadata, STATUS_VALUES, VISIBILITY_VALUES } from '../../interfaces';
 import { t } from '../../services';
@@ -9,64 +8,63 @@ import { ConfigureQuery } from '../ConfigureQuery';
 import css from './EditListResultViewer.module.css';
 
 interface EditListResultViewerProps {
-  id: string,
-  version?: number,
-  entityTypeId?: string,
-  fqlQuery: string,
-  userFriendlyQuery: string,
-  contentVersion: number,
-  fields?: string[],
-  status: string,
-  listName: string,
-  visibility: string,
-  description: string,
-  isDuplicating?: boolean,
-  isQueryButtonDisabled?: boolean,
+  id: string;
+  version?: number;
+  entityTypeId?: string;
+  fqlQuery: string;
+  userFriendlyQuery: string;
+  contentVersion: number;
+  fields?: string[];
+  status: string;
+  listName: string;
+  visibility: string;
+  description: string;
+  isDuplicating?: boolean;
+  isQueryButtonDisabled?: boolean;
   setColumns?: (columns: QueryBuilderColumnMetadata[]) => void;
 }
 
-export const EditListResultViewer:FC<EditListResultViewerProps> = (
-  {
-    id,
-    version,
-    entityTypeId,
-    fqlQuery,
-    userFriendlyQuery = '',
-    contentVersion,
-    status,
-    listName,
-    visibility,
-    description,
-    fields,
-    setColumns,
-    isDuplicating = false,
-    isQueryButtonDisabled = false
-  }
-) => {
+export const EditListResultViewer: FC<EditListResultViewerProps> = ({
+  id,
+  version,
+  entityTypeId,
+  fqlQuery,
+  userFriendlyQuery = '',
+  contentVersion,
+  status,
+  listName,
+  visibility,
+  description,
+  fields,
+  setColumns,
+  isDuplicating = false,
+  isQueryButtonDisabled = false,
+}) => {
   const ky = useOkapiKy();
 
-  const {
-    visibleColumns,
-  } = useVisibleColumns(id);
+  const { visibleColumns } = useVisibleColumns(id);
 
-  const getAsyncContentData = ({ limit, offset }: any) => {
-    return ky.get(`lists/${id}/contents?offset=${offset}&size=${limit}&fields=${visibleColumns?.join(',')}`).json();
-  };
+  const getAsyncContentData = useCallback(
+    ({ limit, offset }: { limit: number; offset: number }) =>
+      ky
+        .get(
+          `lists/${id}/contents?offset=${offset}&size=${limit}&fields=${visibleColumns?.join(',')}`,
+        )
+        .json(),
+    [ky, id, visibleColumns],
+  );
 
-  const getAsyncEntityType = () => {
-    return ky.get(`entity-types/${entityTypeId}`).json();
-  };
+  const getAsyncEntityType = useCallback(
+    () => ky.get(`entity-types/${entityTypeId}`).json(),
+    [ky, entityTypeId],
+  );
 
   return (
     <Pluggable
       type="query-builder"
       componentType="viewer"
-      accordionHeadline={
-        t('accordion.title.query',
-          { query: userFriendlyQuery })}
-      headline={({ totalRecords }: any) => (
-        t('mainPane.subTitle',
-          { count: totalRecords }))}
+      accordionHeadline={t('accordion.title.query', { query: userFriendlyQuery })}
+      headline={({ totalRecords }: any) => t('mainPane.subTitle', { count: totalRecords })}
       refreshTrigger={contentVersion}
       contentDataSource={getAsyncContentData}
       entityTypeDataSource={getAsyncEntityType}
@@ -74,23 +72,27 @@ export const EditListResultViewer:FC<EditListResultViewerProps> = (
       onSetDefaultColumns={setColumns}
       contentQueryKeys={visibleColumns}
       height={500}
-      additionalControls={(
+      additionalControls={
         <div className={css.queryBuilderButton}>
           <ConfigureQuery
             listId={isDuplicating ? undefined : id}
             version={isDuplicating ? undefined : version}
             isEditQuery={!isDuplicating}
-            initialValues={fqlQuery ? JSON.parse(fqlQuery) : undefined}
+            initialValues={useMemo(() => (fqlQuery ? JSON.parse(fqlQuery) : undefined), [fqlQuery])}
             selectedType={entityTypeId}
             recordColumns={fields}
             isQueryButtonDisabled={isQueryButtonDisabled}
             listName={listName}
             status={status === STATUS_VALUES.ACTIVE ? STATUS_VALUES.ACTIVE : STATUS_VALUES.INACTIVE}
-            visibility={visibility === VISIBILITY_VALUES.SHARED ? VISIBILITY_VALUES.SHARED : VISIBILITY_VALUES.PRIVATE}
+            visibility={
+              visibility === VISIBILITY_VALUES.SHARED
+                ? VISIBILITY_VALUES.SHARED
+                : VISIBILITY_VALUES.PRIVATE
+            }
             description={description}
           />
         </div>
-      )}
+      }
     >
       {t('loading-fallback')}
     </Pluggable>

--- a/src/components/EditListResultViewer/EditListResultViewer.tsx
+++ b/src/components/EditListResultViewer/EditListResultViewer.tsx
@@ -7,7 +7,7 @@ import { ConfigureQuery } from '../ConfigureQuery';
 
 import css from './EditListResultViewer.module.css';
 
-interface EditListResultViewerProps {
+export interface EditListResultViewerProps {
   id: string;
   version?: number;
   entityTypeId?: string;

--- a/src/components/EditListResultViewer/EditListResultViewerTest.test.tsx
+++ b/src/components/EditListResultViewer/EditListResultViewerTest.test.tsx
@@ -1,0 +1,74 @@
+import { Pluggable } from '@folio/stripes/core';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { useVisibleColumns } from '../../hooks';
+import { EditListResultViewer, EditListResultViewerProps } from './EditListResultViewer';
+
+const PluggableMock = Pluggable as jest.Mock;
+const useVisibleColumnsMock = useVisibleColumns as jest.Mock;
+
+const kyGetMock = jest.fn(() => ({ json: jest.fn() }));
+const kyPostMock = jest.fn(() => ({ json: jest.fn() }));
+const kyPutMock = jest.fn(() => ({ json: jest.fn() }));
+const kyDeleteMock = jest.fn(() => ({ json: jest.fn() }));
+
+jest.mock('@folio/stripes/core', () => ({
+  Pluggable: jest.fn(() => <div>Pluggable</div>),
+  useOkapiKy: jest.fn(() => ({
+    get: kyGetMock,
+    post: kyPostMock,
+    put: kyPutMock,
+    delete: kyDeleteMock,
+  })),
+}));
+
+jest.mock('../../hooks', () => ({
+  useVisibleColumns: jest.fn(() => ({})),
+}));
+
+function renderComponent(props: Partial<EditListResultViewerProps>) {
+  return render(<EditListResultViewer {...(props as EditListResultViewerProps)} />);
+}
+
+describe('EditListResultViewer component', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders', () => {
+    renderComponent({} as any);
+
+    expect(screen.getByText('Pluggable')).toBeInTheDocument();
+  });
+
+  describe('content data callbacks', () => {
+    it('properly queries content with visibleColumns=null', () => {
+      useVisibleColumnsMock.mockReturnValueOnce({ visibleColumns: null });
+      renderComponent({ id: 'id' });
+
+      PluggableMock.mock.lastCall[0].contentDataSource({ limit: 10, offset: 0 });
+
+      // we don't care what fields= here, since we have no list of visible columns
+      expect(kyGetMock).toHaveBeenCalledWith('lists/id/contents?offset=0&size=10&fields=undefined');
+    });
+
+    it('properly queries content with visibleColumns', () => {
+      useVisibleColumnsMock.mockReturnValueOnce({ visibleColumns: ['a', 'b', 'c'] });
+      renderComponent({ id: 'id' });
+
+      PluggableMock.mock.lastCall[0].contentDataSource({ limit: 10, offset: 0 });
+
+      expect(kyGetMock).toHaveBeenCalledWith('lists/id/contents?offset=0&size=10&fields=a,b,c');
+    });
+  });
+
+  describe('entity type callback', () => {
+    it('hits correct endpoint', () => {
+      renderComponent({ entityTypeId: 'entity-type-here' });
+
+      PluggableMock.mock.lastCall[0].entityTypeDataSource();
+
+      expect(kyGetMock).toHaveBeenCalledWith('entity-types/entity-type-here');
+    });
+  });
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  }
+}


### PR DESCRIPTION
An un-memoized call to `JSON.parse` was decoding the `initialValues` on every render of `EditListResultViewer`. As a result, despite any real changes to the `initialValues`, downstream hooks and effects that relied on `initialValues` were reset, causing us to lose state.

This was a hard one to debug, since the problem occurred many levels deeper inside the query builder, and the error only occurred on RTR refreshes, making reproduction slow and tedious. The reason this affected us in this way is that, on RTR refresh, `useOkapiKy` returns an updated `ky` (with a new auth token) and, since `EditListResultViewer` uses this hook, it got rerendered, thus sparking the chain of re-renders.

There will be a companion PR in the query builder to improve memoization, too.