### PR TITLE
[FOLIO-4086] Fix GitHub Actions workflow not running for tags

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -7,7 +7,8 @@ on:
 jobs:
   ui:
     uses: folio-org/.github/.github/workflows/ui.yml@v1
-    if: github.ref_name == github.event.repository.default_branch || github.event_name != 'push'
+    # Only handle push events from the main branch or tags, to decrease PR noise
+    if: github.ref_name == github.event.repository.default_branch || github.event_name != 'push' || github.ref_type == 'tag'
     secrets: inherit
     with:
       jest-enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Change save/cancel buttons styles [UILISTS-183]
 * Fix issue with absent blue bar [UILISTS-172]
 * Add cross-tenant logic for list-table [UILISTS-185]
+* Fix GitHub Actions workflow not running for tags [FOLIO-4086]
 
 [UILISTS-185] https://folio-org.atlassian.net/browse/UILISTS-185
 [UILISTS-182] https://folio-org.atlassian.net/browse/UILISTS-182
@@ -26,6 +27,7 @@
 [UILISTS-137] https://folio-org.atlassian.net/browse/UILISTS-137
 [UILISTS-145] https://folio-org.atlassian.net/browse/UILISTS-145
 [UILISTS-158] https://folio-org.atlassian.net/browse/UILISTS-158
+[FOLIO-4086] https://folio-org.atlassian.net/browse/FOLIO-4086
 
 ## [3.0.2](https://github.com/folio-org/ui-lists/tree/v3.0.2) (2024-08-07)
 * Fix type issue with `<DropdownMenu>` [UILISTS-168]


### PR DESCRIPTION
# [Jira FOLIO-4086](https://folio-org.atlassian.net/browse/FOLIO-4086)

Due to an error in the [recommended configuration for shared workflows](https://github.com/folio-org/.github/blob/master/README-UI.md), an incorrect conditional was added to the workflow which can cause GitHub Actions to not run on tags, making it impossible to release this module.

This PR resolves this by adjusting the condition to always run the workflow for pushes to tags.
