### PR TITLE
[UILISTS-175] Add changing visibility to shared for non cross-tenant lists

### DIFF
--- a/src/pages/createlist/hooks/useCreateListState.ts
+++ b/src/pages/createlist/hooks/useCreateListState.ts
@@ -26,6 +26,8 @@ export const useCreateListFormState = () => {
 
     if (isCrossTenant(value[FIELD_NAMES.RECORD_TYPE])) {
       value = { ...value, [FIELD_NAMES.VISIBILITY]: VISIBILITY_VALUES.PRIVATE };
+    } else {
+      value = { ...value, [FIELD_NAMES.VISIBILITY]: VISIBILITY_VALUES.SHARED };
     }
 
     setState((prevState) => {


### PR DESCRIPTION
Addition to [UILISTS-175](https://folio-org.atlassian.net/browse/UILISTS-175)

Add logic to change visibility back to shared automatically when the user selects the non-cross-tenant type 

Demo record: 

https://github.com/user-attachments/assets/adc5f3b7-bac7-4272-81da-2bd3d518f070

