### PR TITLE
UILISTS-195 supply a11y props to Layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Cross-tenant indicator for list detail page [UILISTS-173]
 * Fix GitHub Actions workflow not running for tags [FOLIO-4086]
 * Add Cross-tenant default state for edit/duplicate/create modes [UILISTS-175]
+* Supply necessary a11y props to `<Layer>` [UILISTS-195]
 
 
 [UILISTS-175] https://folio-org.atlassian.net/browse/UILISTS-175

--- a/src/pages/createlist/components/CreateListLayout/CreateListLayout.tsx
+++ b/src/pages/createlist/components/CreateListLayout/CreateListLayout.tsx
@@ -1,7 +1,8 @@
 import React, { FC, ReactElement, useState } from 'react';
+import { useIntl } from 'react-intl';
 import { Layer, Loading, Pane, PaneFooter, Paneset } from '@folio/stripes/components';
 import { CancelEditModal, ListAppIcon, Buttons } from '../../../../components';
-import { t } from '../../../../services';
+import { t, tString } from '../../../../services';
 
 type CreateListLayoutProps = {
     isSaveButtonDisabled?: boolean;
@@ -23,6 +24,7 @@ export const CreateListLayout:FC<CreateListLayoutProps> = ({
   children
 }) => {
   const [showConfirmCancelEditModal, setShowConfirmCancelEditModal] = useState(false);
+  const intl = useIntl();
 
   const cancelHandler = () => {
     if (showModalOnCancel) {
@@ -34,7 +36,7 @@ export const CreateListLayout:FC<CreateListLayoutProps> = ({
 
   return (
     <Paneset>
-      <Layer isOpen>
+      <Layer isOpen contentLabel={tString(intl, 'create-list.title')}>
         <Paneset isRoot>
           <Pane
             dismissible


### PR DESCRIPTION
Supply `contentLabel` to `<Layer>` in `<CreateListLayout>` to avoid a11y warnings in the JS console.

Refs [UILISTS-195](https://folio-org.atlassian.net/browse/UILISTS-195)