### PR TITLE
[UIPQB-126] Use tenant timezone for building queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change history for ui-lists
 
+## IN PROGRESS
 * Remove backslashes from user-friendly query string [UILISTS-196]
+* Use tenant timezone for building queries (adds use of permission `configuration.entries.collection.get`) [UIPQB-126]
+
+[UILISTS-196]: https://folio-org.atlassian.net/browse/UILISTS-196
+[UIPQB-126]: https://folio-org.atlassian.net/browse/UIPQB-126
 
 ## [3.1.1](https://github.com/folio-org/ui-lists/tree/v3.1.1) (2024-11-05)
 * Update `stripes-acq-components` to 6.0.0 [UILISTS-197]

--- a/package.json
+++ b/package.json
@@ -122,7 +122,8 @@
           "lists.collection.get",
           "lists.item.get",
           "lists.item.contents.get",
-          "lists.configuration.get"
+          "lists.configuration.get",
+          "configuration.entries.collection.get"
         ]
       },
       {


### PR DESCRIPTION
The real work is being done in https://github.com/folio-org/ui-plugin-query-builder/pull/180; this just adds the new permission required by the query builder.

We need access to `mod-configuration` to retrieve the tenant locale information, as this is not made available by Stripes (Stripes exposes either the tenant locale, or the user locale if one is set, but not both). `mod-fqm-manager` is not aware of user timezones, so queries will always be built with regard to tenant timezone.

## Must be merged before https://github.com/folio-org/ui-plugin-query-builder/pull/180