### PR TITLE
UILISTS-199 Remove module declaration for `@folio/stripes-acq-components` in the `global.d.ts` file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## IN PROGRESS
 * Remove backslashes from user-friendly query string [UILISTS-196]
 * Use tenant timezone for building queries (adds use of permission `configuration.entries.collection.get`) [UIPQB-126]
+* Remove module declaration for `@folio/stripes-acq-components` in the `global.d.ts` file [UILISTS-199]
 
 [UILISTS-196]: https://folio-org.atlassian.net/browse/UILISTS-196
 [UIPQB-126]: https://folio-org.atlassian.net/browse/UIPQB-126

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,5 +1,3 @@
-declare module '@folio/stripes-acq-components';
-
 declare module '*.css' {
   const styles: { [className: string]: string };
   export = styles;


### PR DESCRIPTION
## Purpose

Jira ticket - https://folio-org.atlassian.net/browse/UILISTS-199

`@folio/stripes-acq-components` library does export of types https://github.com/folio-org/stripes-acq-components/blob/master/index.d.ts In turn, the library stores code typing in `@folio/stripes-types` https://github.com/folio-org/stripes-types/tree/master/acq-components .

Modules dependent on `@folio/stripes-acq-components` should not declare `@folio/stripes-acq-components`, as this may cause incorrect assembly at the platform level.