### PR TITLE
UILISTS-198: [ESC] The visibility for cross tenant record types changes to "Shared" when the user makes any changes after selecting the entity type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## IN PROGRESS
 
+* [ECS] The visibility for cross tenant record types changes to "Shared" when the user makes any changes after selecting the entity type [UILISTS-198]
+
 ## [3.1.2](https://github.com/folio-org/ui-lists/tree/v3.1.2) (2024-11-12)
 * Remove backslashes from user-friendly query string [UILISTS-196]
 * Use tenant timezone for building queries (adds use of permission `configuration.entries.collection.get`) [UIPQB-126]

--- a/src/hooks/useCrossTenantCheck/useCrossTenantCheck.tsx
+++ b/src/hooks/useCrossTenantCheck/useCrossTenantCheck.tsx
@@ -4,7 +4,7 @@ import { useRecordTypes } from '../useRecordTypes';
 export const useCrossTenantCheck = () => {
   const { recordTypes } = useRecordTypes();
 
-  const isCrossTenant = (id: string) => {
+  const isCrossTenant = (id: string | undefined) => {
     const recordType = recordTypes.find(({ id: savedId }) => id === savedId);
 
     return Boolean(recordType?.crossTenantQueriesEnabled);

--- a/src/pages/createlist/hooks/tests/useCreateListState.test.tsx
+++ b/src/pages/createlist/hooks/tests/useCreateListState.test.tsx
@@ -75,4 +75,35 @@ describe('useCreateListFormState', () => {
 
     expect(result.current.state.visibility).toBe(VISIBILITY_VALUES.SHARED);
   });
+
+  it('should update visibility to SHARED if record is non-cross-tenant', () => {
+    const mockIsCrossTenant = jest.fn().mockReturnValue(true);
+    jest.mock('../../../../hooks', () => ({
+      useCrossTenantCheck: () => ({ isCrossTenant: mockIsCrossTenant }),
+    }));
+
+    const { result } = renderHook(() => useCreateListFormState(), { wrapper });
+
+    act(() => {
+      result.current.onValueChange({ recordType: 'some type' });
+    });
+
+    expect(result.current.state.visibility).toBe(VISIBILITY_VALUES.SHARED);
+  });
+
+  it('should stay PRIVATE if record type is cross-tenant', () => {
+    const mockIsCrossTenant = jest.fn().mockReturnValue(false);
+    jest.mock('../../../../hooks', () => ({
+      useCrossTenantCheck: () => ({ isCrossTenant: mockIsCrossTenant }),
+    }));
+
+    const { result } = renderHook(() => useCreateListFormState(), { wrapper });
+
+    act(() => {
+      result.current.onValueChange({ recordType: 'cross-tenant' });
+      result.current.onValueChange({ visibility: VISIBILITY_VALUES.PRIVATE });
+    });
+
+    expect(result.current.state.visibility).toBe(VISIBILITY_VALUES.PRIVATE);
+  });
 });

--- a/src/pages/createlist/hooks/tests/useCreateListState.test.tsx
+++ b/src/pages/createlist/hooks/tests/useCreateListState.test.tsx
@@ -76,7 +76,7 @@ describe('useCreateListFormState', () => {
     expect(result.current.state.visibility).toBe(VISIBILITY_VALUES.SHARED);
   });
 
-  it('should update visibility to SHARED if record is non-cross-tenant', () => {
+  it('should set visibility to Shared if recordType is non-cross-tenant', () => {
     const mockIsCrossTenant = jest.fn().mockReturnValue(true);
     jest.mock('../../../../hooks', () => ({
       useCrossTenantCheck: () => ({ isCrossTenant: mockIsCrossTenant }),
@@ -85,13 +85,13 @@ describe('useCreateListFormState', () => {
     const { result } = renderHook(() => useCreateListFormState(), { wrapper });
 
     act(() => {
-      result.current.onValueChange({ recordType: 'some type' });
+      result.current.onValueChange({ recordType: 'cross-tenant' });
     });
 
     expect(result.current.state.visibility).toBe(VISIBILITY_VALUES.SHARED);
   });
 
-  it('should stay PRIVATE if record type is cross-tenant', () => {
+  it('should set visibility to SHARED if current visibility is PRIVATE and incoming visibility is not PRIVATE', () => {
     const mockIsCrossTenant = jest.fn().mockReturnValue(false);
     jest.mock('../../../../hooks', () => ({
       useCrossTenantCheck: () => ({ isCrossTenant: mockIsCrossTenant }),
@@ -100,7 +100,33 @@ describe('useCreateListFormState', () => {
     const { result } = renderHook(() => useCreateListFormState(), { wrapper });
 
     act(() => {
-      result.current.onValueChange({ recordType: 'cross-tenant' });
+      result.current.onValueChange({ visibility: VISIBILITY_VALUES.PRIVATE });
+    });
+
+    expect(result.current.state.visibility).toBe(VISIBILITY_VALUES.PRIVATE);
+
+    act(() => {
+      result.current.onValueChange({ visibility: VISIBILITY_VALUES.SHARED });
+    });
+
+    expect(result.current.state.visibility).toBe(VISIBILITY_VALUES.SHARED);
+  });
+
+  it('should not change visibility if current visibility is PRIVATE and incoming visibility is also PRIVATE', () => {
+    const mockIsCrossTenant = jest.fn().mockReturnValue(false);
+    jest.mock('../../../../hooks', () => ({
+      useCrossTenantCheck: () => ({ isCrossTenant: mockIsCrossTenant }),
+    }));
+
+    const { result } = renderHook(() => useCreateListFormState(), { wrapper });
+
+    act(() => {
+      result.current.onValueChange({ visibility: VISIBILITY_VALUES.PRIVATE });
+    });
+
+    expect(result.current.state.visibility).toBe(VISIBILITY_VALUES.PRIVATE);
+
+    act(() => {
       result.current.onValueChange({ visibility: VISIBILITY_VALUES.PRIVATE });
     });
 

--- a/src/pages/createlist/hooks/useCreateListState.ts
+++ b/src/pages/createlist/hooks/useCreateListState.ts
@@ -22,23 +22,23 @@ export const useCreateListFormState = () => {
   const [state, setState] = useState(initialState);
 
   const getUpdatedVisibility = (
-      recordType: string,
-      currentVisibility: VISIBILITY_VALUES,
-      incomingVisibility?: VISIBILITY_VALUES
+    recordType: string,
+    currentVisibility: VISIBILITY_VALUES,
+    incomingVisibility?: VISIBILITY_VALUES
   ): VISIBILITY_VALUES => {
     if (isCrossTenant(recordType)) {
       return VISIBILITY_VALUES.PRIVATE;
     }
 
     if (
-        currentVisibility === VISIBILITY_VALUES.PRIVATE &&
+      currentVisibility === VISIBILITY_VALUES.PRIVATE &&
         incomingVisibility !== VISIBILITY_VALUES.PRIVATE
     ) {
       return VISIBILITY_VALUES.SHARED;
     }
 
     return incomingVisibility || currentVisibility;
-  }
+  };
 
   const onValueChange = useCallback((rawValue: ChangedFieldType) => {
     setState((prevState) => {
@@ -52,6 +52,7 @@ export const useCreateListFormState = () => {
 
       return updatedState;
     });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const hasDirtyFields = Boolean(JSON.stringify(initialState) !== JSON.stringify(state));

--- a/src/pages/createlist/hooks/useCreateListState.ts
+++ b/src/pages/createlist/hooks/useCreateListState.ts
@@ -52,8 +52,9 @@ export const useCreateListFormState = () => {
 
       return updatedState;
     });
-
-  }, [getUpdatedVisibility]);
+    // // We don't add `getUpdatedVisibility` to dependencies because it's defined within the same closure and does not change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const hasDirtyFields = Boolean(JSON.stringify(initialState) !== JSON.stringify(state));
 

--- a/src/pages/createlist/hooks/useCreateListState.ts
+++ b/src/pages/createlist/hooks/useCreateListState.ts
@@ -38,7 +38,7 @@ export const useCreateListFormState = () => {
         return VISIBILITY_VALUES.SHARED;
       }
 
-      return incomingVisibility || currentVisibility;
+      return incomingVisibility ?? currentVisibility;
     };
     setState((prevState) => {
       const updatedState = { ...prevState, ...rawValue };

--- a/src/pages/createlist/hooks/useCreateListState.ts
+++ b/src/pages/createlist/hooks/useCreateListState.ts
@@ -21,26 +21,25 @@ export const useCreateListFormState = () => {
 
   const [state, setState] = useState(initialState);
 
-  const getUpdatedVisibility = (
-    recordType: string,
-    currentVisibility: VISIBILITY_VALUES,
-    incomingVisibility?: VISIBILITY_VALUES
-  ): VISIBILITY_VALUES => {
-    if (isCrossTenant(recordType)) {
-      return VISIBILITY_VALUES.PRIVATE;
-    }
-
-    if (
-      currentVisibility === VISIBILITY_VALUES.PRIVATE &&
-        incomingVisibility !== VISIBILITY_VALUES.PRIVATE
-    ) {
-      return VISIBILITY_VALUES.SHARED;
-    }
-
-    return incomingVisibility || currentVisibility;
-  };
-
   const onValueChange = useCallback((rawValue: ChangedFieldType) => {
+    const getUpdatedVisibility = (
+      recordType: string,
+      currentVisibility: VISIBILITY_VALUES,
+      incomingVisibility?: VISIBILITY_VALUES
+    ): VISIBILITY_VALUES => {
+      if (isCrossTenant(recordType)) {
+        return VISIBILITY_VALUES.PRIVATE;
+      }
+
+      if (
+        currentVisibility === VISIBILITY_VALUES.PRIVATE &&
+          incomingVisibility !== VISIBILITY_VALUES.PRIVATE
+      ) {
+        return VISIBILITY_VALUES.SHARED;
+      }
+
+      return incomingVisibility || currentVisibility;
+    };
     setState((prevState) => {
       const updatedState = { ...prevState, ...rawValue };
 
@@ -52,9 +51,7 @@ export const useCreateListFormState = () => {
 
       return updatedState;
     });
-    // // We don't add `getUpdatedVisibility` to dependencies because it's defined within the same closure and does not change.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [isCrossTenant]);
 
   const hasDirtyFields = Boolean(JSON.stringify(initialState) !== JSON.stringify(state));
 

--- a/src/pages/createlist/hooks/useCreateListState.ts
+++ b/src/pages/createlist/hooks/useCreateListState.ts
@@ -52,8 +52,8 @@ export const useCreateListFormState = () => {
 
       return updatedState;
     });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+
+  }, [getUpdatedVisibility]);
 
   const hasDirtyFields = Boolean(JSON.stringify(initialState) !== JSON.stringify(state));
 


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UILISTS-198

Here we change the logic for `cross-tenant` visibility changes, after calling `onChange`


https://github.com/user-attachments/assets/9a1fbf6b-0fa4-4f64-b0f4-916a8e7c66f7

