### PR TITLE
UILISTS-161: Stop polling after X attempts result in 500 errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## IN PROGRESS
 
+* Stop polling after X attempts result in 500 errors [UILISTS-161].
 * [ECS] The visibility for cross tenant record types changes to "Shared" when the user makes any changes after selecting the entity type [UILISTS-198]
 
 ## [3.1.2](https://github.com/folio-org/ui-lists/tree/v3.1.2) (2024-11-12)

--- a/src/components/ConfigureQuery/ConfigureQuery.tsx
+++ b/src/components/ConfigureQuery/ConfigureQuery.tsx
@@ -71,7 +71,11 @@ export const ConfigureQuery: FC<ConfigureQueryProps> = ({
       limit,
     };
 
-    return ky.get(`query/${queryId}`, { searchParams }).json();
+    try {
+      return await ky.get(`query/${queryId}`, { searchParams }).json();
+    } catch (error) {
+      throw error;
+    }
   };
 
   const testQueryDataSource = async ({ fqlQuery }: { fqlQuery: FqlQuery }) => {


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UILISTS-161

Here we simply added `catch` block into `queryDetailsDataSource` to use that error in query-plugin-builder to stop polling after 3 attempts.

It should work after https://github.com/folio-org/ui-plugin-query-builder/pull/184 is merged.

https://github.com/user-attachments/assets/4866fc7a-8b08-441f-87d8-7957124043e2


