### PR TITLE
UILISTS-177: Prompt for unsaved changes when clicking on the Lists app home from the app context menu(follow-up)

### DIFF
--- a/src/hooks/useNavigationBlock/useNavigationBlock.ts
+++ b/src/hooks/useNavigationBlock/useNavigationBlock.ts
@@ -33,12 +33,12 @@ export const useNavigationBlock = (showModalOnCancel: boolean, isSaving = false)
     }
 
     if (showModalOnCancel && !isBlocked) {
+      // @ts-ignore
       unblock = history.block((next) => {
-
         const isListPath = /^\/lists\/list\/[0-9a-fA-F-]+$/.test(next.pathname);
 
         if (isListPath) {
-          return;
+          return true;
         }
 
         setShowConfirmCancelEditModal(true);
@@ -49,6 +49,8 @@ export const useNavigationBlock = (showModalOnCancel: boolean, isSaving = false)
       });
     }
 
+    // here we need a clean-up function for useEffect
+    // eslint-disable-next-line consistent-return
     return () => {
       if (unblock) unblock();
     };

--- a/src/hooks/useNavigationBlock/useNavigationBlock.ts
+++ b/src/hooks/useNavigationBlock/useNavigationBlock.ts
@@ -34,6 +34,13 @@ export const useNavigationBlock = (showModalOnCancel: boolean, isSaving = false)
 
     if (showModalOnCancel && !isBlocked) {
       unblock = history.block((next) => {
+
+        const isListPath = /^\/lists\/list\/[0-9a-fA-F-]+$/.test(next.pathname);
+
+        if (isListPath) {
+          return;
+        }
+
         setShowConfirmCancelEditModal(true);
         setNextLocation(next);
         setIsBlocked(true);

--- a/src/pages/createlist/CreateListPage.test.tsx
+++ b/src/pages/createlist/CreateListPage.test.tsx
@@ -207,8 +207,6 @@ describe('CreateList Page', () => {
               await user.click(conformationCancelButton);
 
               expect(conformationModal).not.toBeInTheDocument();
-
-              expect(historyPushMock).not.toBeCalled();
             });
           });
         });

--- a/src/pages/createlist/components/CreateListLayout/CreateListLayout.tsx
+++ b/src/pages/createlist/components/CreateListLayout/CreateListLayout.tsx
@@ -34,11 +34,8 @@ export const CreateListLayout: FC<CreateListLayoutProps> = ({
   } = useNavigationBlock(showModalOnCancel);
 
   const cancelHandler = () => {
-    if (showModalOnCancel) {
-      setShowConfirmCancelEditModal(true);
-    } else {
+      continueNavigation();
       onCancel();
-    }
   };
 
   return (
@@ -75,9 +72,8 @@ export const CreateListLayout: FC<CreateListLayoutProps> = ({
             {children}
             <CancelEditModal
               onCancel={() => {
+                cancelHandler();
                 setShowConfirmCancelEditModal(false);
-                onClose();
-                continueNavigation();
               }}
               onKeepEdit={keepEditHandler}
               open={showModalOnCancel && showConfirmCancelEditModal}

--- a/src/pages/createlist/components/CreateListLayout/CreateListLayout.tsx
+++ b/src/pages/createlist/components/CreateListLayout/CreateListLayout.tsx
@@ -34,8 +34,11 @@ export const CreateListLayout: FC<CreateListLayoutProps> = ({
   } = useNavigationBlock(showModalOnCancel);
 
   const cancelHandler = () => {
-      continueNavigation();
-      onCancel();
+    if (!showConfirmCancelEditModal) {
+      setShowConfirmCancelEditModal(true);
+    }
+    continueNavigation();
+    onCancel();
   };
 
   return (

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,9 +18,6 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react",
-    "paths": {
-      "react": [ "./node_modules/@types/react" ]
-    }
   },
   "include": ["src", "**/*.ts", "**/*.tsx", "**/*.test.ts", "**/*.test.tsx"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UILISTS-177

Here small fix for the existing implementation. Modal list saving is unblocked for the redirect.