### PR TITLE
UILISTS-203: Don't revert visibility setting when creating a new list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@
 
 * Lists > Errors when query includes a deleted custom field [UILISTS-205]
 * Prompt for unsaved changes when clicking on the Lists app home from the app context menu [UILISTS-177]
+* Don't revert visibility setting when creating a new list. [UILISTS-203]
 
 [UILISTS-177]: https://folio-org.atlassian.net/browse/UILISTS-177
 [UILISTS-205]: https://folio-org.atlassian.net/browse/UILISTS-205
+[UILISTS-203]: https://folio-org.atlassian.net/browse/UILISTS-203
 
 ## [3.1.3](https://github.com/folio-org/ui-lists/tree/v3.1.3) (2024-11-27)
 * Stop polling after X attempts result in 500 errors [UILISTS-161]

--- a/src/pages/createlist/hooks/useCreateListState.ts
+++ b/src/pages/createlist/hooks/useCreateListState.ts
@@ -31,13 +31,6 @@ export const useCreateListFormState = () => {
         return VISIBILITY_VALUES.PRIVATE;
       }
 
-      if (
-        currentVisibility === VISIBILITY_VALUES.PRIVATE &&
-          incomingVisibility !== VISIBILITY_VALUES.PRIVATE
-      ) {
-        return VISIBILITY_VALUES.SHARED;
-      }
-
       return incomingVisibility ?? currentVisibility;
     };
     setState((prevState) => {


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UILISTS-203

Here we removed logic for auto-changing the visibility while creating the list.


https://github.com/user-attachments/assets/2ccad3df-b8f6-4642-9d30-a10ac60bde76

