### PR TITLE
UILISTS-211: The filters reset after closing list on nth pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change history for ui-lists
 
+## In progress
+
+* The filters reset after closing list on nth pages. [UILISTS-211]
+
+[UILISTS-211]: https://folio-org.atlassian.net/browse/UILISTS-211
+
 ## [3.1.4](https://github.com/folio-org/ui-lists/tree/v3.1.4) (2025-01-09)
 
 * Lists > Errors when query includes a deleted custom field [UILISTS-205]

--- a/src/components/ListsTable/ListsTable.tsx
+++ b/src/components/ListsTable/ListsTable.tsx
@@ -27,9 +27,11 @@ export const ListsTable: FC<ListsTableProps> = ({
   } = useListsPagination({});
   const { updatedListsData, setRecordIds } = useListsIdsToTrack();
 
-  const prevActiveFilters: string[] = usePrevious(activeFilters) || [];
+  const prevActiveFilters: string[] = usePrevious(activeFilters);
 
   useEffect(() => {
+    if (prevActiveFilters === undefined) return;
+
     if (prevActiveFilters && !isEqual(prevActiveFilters, activeFilters)) {
       gotToFirstPage();
       setRecordIds([]);

--- a/src/components/ListsTable/ListsTable.tsx
+++ b/src/components/ListsTable/ListsTable.tsx
@@ -27,7 +27,7 @@ export const ListsTable: FC<ListsTableProps> = ({
   } = useListsPagination({});
   const { updatedListsData, setRecordIds } = useListsIdsToTrack();
 
-  const prevActiveFilters: string[] = usePrevious(activeFilters);
+  const prevActiveFilters: string[] | undefined = usePrevious(activeFilters);
 
   useEffect(() => {
     if (prevActiveFilters === undefined) return;

--- a/src/components/ListsTable/helpers/formatters.tsx
+++ b/src/components/ListsTable/helpers/formatters.tsx
@@ -9,9 +9,8 @@ import { ListsRecord } from '../../../interfaces';
 
 export const listTableResultFormatter: Record<string, (item: ListsRecord) => React.JSX.Element> = {
   [COLUMNS_NAME.LIST_NAME]: (item) => {
-    // Используем window.location для получения параметров URL
-    const searchParams = window.location.search;  // Получаем строку запроса из URL
-    const linkTo = `${HOME_PAGE_URL}/list/${item.id}${searchParams}`;  // Формируем новый URL с параметрами
+    const searchParams = window.location.search;
+    const linkTo = `${HOME_PAGE_URL}/list/${item.id}${searchParams}`;
     return (
       <TextLink to={linkTo}>{item.name}</TextLink>
     );

--- a/src/components/ListsTable/helpers/formatters.tsx
+++ b/src/components/ListsTable/helpers/formatters.tsx
@@ -8,9 +8,14 @@ import { HOME_PAGE_URL, COLUMNS_NAME } from '../../../constants';
 import { ListsRecord } from '../../../interfaces';
 
 export const listTableResultFormatter: Record<string, (item: ListsRecord) => React.JSX.Element> = {
-  [COLUMNS_NAME.LIST_NAME]: (item) => (
-    <TextLink to={`${HOME_PAGE_URL}/list/${item.id}`}>{item.name}</TextLink>
-  ),
+  [COLUMNS_NAME.LIST_NAME]: (item) => {
+    // Используем window.location для получения параметров URL
+    const searchParams = window.location.search;  // Получаем строку запроса из URL
+    const linkTo = `${HOME_PAGE_URL}/list/${item.id}${searchParams}`;  // Формируем новый URL с параметрами
+    return (
+      <TextLink to={linkTo}>{item.name}</TextLink>
+    );
+  },
   [COLUMNS_NAME.STATUS]: (item) => (
     t(item.isActive
       ? 'lists.item.active'

--- a/src/pages/copylist/CopyListPage.test.tsx
+++ b/src/pages/copylist/CopyListPage.test.tsx
@@ -121,7 +121,7 @@ describe('CopyList Page', () => {
 
         await user.click(closeButton);
 
-        expect(historyPushMock).toBeCalledWith('/lists/list/id');
+        expect(historyPushMock).toBeCalledWith({ pathname: '/lists/list/id', search: '' });
       });
     });
 
@@ -147,7 +147,7 @@ describe('CopyList Page', () => {
 
         await user.click(cancelButton);
 
-        expect(historyPushMock).toBeCalledWith('/lists/list/id');
+        expect(historyPushMock).toBeCalledWith({ pathname: '/lists/list/id', search: '' });
       });
     });
     describe('Disable/Enable save button', () => {

--- a/src/pages/copylist/CopyListPage.tsx
+++ b/src/pages/copylist/CopyListPage.tsx
@@ -52,7 +52,13 @@ export const CopyListPage:FC = () => {
   };
 
   const backToList = () => {
-    history.push(`${HOME_PAGE_URL}/list/${id}`);
+    const searchParams = new URLSearchParams(window.location.search).toString();
+    history.push(
+      {
+        pathname: `${HOME_PAGE_URL}/list/${id}`,
+        search: searchParams,
+      }
+    );
   };
 
   const { initRefresh } = useInitRefresh({ onSuccess: (data) => {

--- a/src/pages/editlist/EditListPage.test.tsx
+++ b/src/pages/editlist/EditListPage.test.tsx
@@ -93,7 +93,7 @@ describe('EditList Page', () => {
 
         await user.click(closeButton);
 
-        expect(historyPushMock).toBeCalledWith('/lists/list/id');
+        expect(historyPushMock).toBeCalledWith({ pathname: '/lists/list/id', search: '' });
       });
     });
 
@@ -127,7 +127,7 @@ describe('EditList Page', () => {
 
           await user.click(cancelButton);
 
-          expect(historyPushMock).toBeCalledWith('/lists/list/id');
+          expect(historyPushMock).toBeCalledWith({ pathname: '/lists/list/id', search: '' });
         });
       });
 
@@ -346,7 +346,7 @@ describe('EditList Page', () => {
 
           await waitFor(() => expect(saveButton).toBeDisabled());
 
-          await waitFor(() => expect(historyPushMock).toBeCalledWith('/lists/list/id'));
+          await waitFor(() => expect(historyPushMock).toBeCalledWith({ pathname: '/lists/list/id', search: '' }));
 
           const successMessage = JSON.stringify(showSuccessMessageHookMock.mock.lastCall);
           expect(successMessage).toContain('ui-lists.callout.list.save.success');
@@ -390,7 +390,7 @@ describe('EditList Page', () => {
 
           await waitFor(() => expect(saveButton).toBeDisabled());
 
-          await waitFor(() => expect(historyPushMock).toBeCalledWith('/lists/list/id'));
+          await waitFor(() => expect(historyPushMock).toBeCalledWith({ pathname: '/lists/list/id', search: '' }));
 
           const successMessage = JSON.stringify(showSuccessMessageHookMock.mock.lastCall);
           expect(successMessage).toContain('ui-lists.callout.list.active');

--- a/src/pages/editlist/EditListPage.tsx
+++ b/src/pages/editlist/EditListPage.tsx
@@ -100,7 +100,11 @@ export const EditListPage:FC = () => {
 
   const backToList = () => {
     continueNavigation();
-    history.push(`${HOME_PAGE_URL}/list/${id}`);
+    const searchParams = new URLSearchParams(window.location.search).toString();
+    history.push({
+      pathname: `${HOME_PAGE_URL}/list/${id}`,
+      search: searchParams
+    });
     setIsSaving(false);
   };
 

--- a/src/pages/listInformation/ListInformationPage.test.tsx
+++ b/src/pages/listInformation/ListInformationPage.test.tsx
@@ -12,13 +12,14 @@ import { queryClient } from '../../../test/utils';
 import * as hooks from '../../hooks';
 
 const historyPushMock = jest.fn();
+const historyGoBack = jest.fn();
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useParams: () => ({
     id: 'id',
   }),
-  useHistory: jest.fn(() => ({ push: historyPushMock })),
+  useHistory: jest.fn(() => ({ push: historyPushMock, goBack: historyGoBack })),
 }));
 
 const renderListInformation = () => {
@@ -63,7 +64,7 @@ describe('ListInformationPage Page', () => {
 
         await user.click(closeButton);
 
-        expect(historyPushMock).toBeCalled();
+        expect(historyGoBack).toBeCalled();
       });
     });
 

--- a/src/pages/listInformation/ListInformationPage.test.tsx
+++ b/src/pages/listInformation/ListInformationPage.test.tsx
@@ -64,7 +64,7 @@ describe('ListInformationPage Page', () => {
 
         await user.click(closeButton);
 
-        expect(historyGoBack).toBeCalled();
+        expect(historyPushMock).toBeCalled();
       });
     });
 
@@ -118,7 +118,7 @@ describe('ListInformationPage Page', () => {
 
             await user.click(conformationDeleteButton);
 
-            await waitFor(() => expect(historyPushMock).toBeCalledWith('/lists'));
+            await waitFor(() => expect(historyPushMock).toBeCalledWith({ pathname: '/lists', search: '' }));
 
             const successMessage = JSON.stringify(showSuccessMessageMock.mock.lastCall);
             expect(successMessage).toContain('ui-lists.callout.list.delete.success');
@@ -207,7 +207,7 @@ describe('ListInformationPage Page', () => {
 
           await user.click(editList);
 
-          await waitFor(() => expect(historyPushMock).toBeCalledWith('id/edit'));
+          await waitFor(() => expect(historyPushMock).toBeCalledWith({ pathname: 'id/edit', search: '' }));
         });
       });
     });

--- a/src/pages/listInformation/ListInformationPage.tsx
+++ b/src/pages/listInformation/ListInformationPage.tsx
@@ -281,7 +281,7 @@ export const ListInformationPage: React.FC = () => {
                   buttonHandlers={buttonHandlers}
                   conditions={conditions}
                 />}
-                onClose={() => history.push(HOME_PAGE_URL)}
+                onClose={() => history.goBack()}
                 subheader={
                   <SubHeaderBannersLayout hasBannersToDisplay={shouldShowCrossTenantWarning || showSuccessRefreshMessage}>
                     <CrossTenantListWarning shouldShow={shouldShowCrossTenantWarning} />

--- a/src/pages/listInformation/ListInformationPage.tsx
+++ b/src/pages/listInformation/ListInformationPage.tsx
@@ -65,6 +65,14 @@ export const ListInformationPage: React.FC = () => {
   const { id }: {id: string} = useParams();
   const accordionStatusRef = useRef(null);
   const { isCrossTenant } = useCrossTenantCheck();
+  const handleUpdateLocation = (location : string) => {
+    const searchParams = new URLSearchParams(window.location.search).toString();
+    history.push({
+      pathname: location,
+      search: searchParams,
+    });
+  };
+
   const {
     handleColumnsChange,
     visibleColumns,
@@ -140,7 +148,7 @@ export const ListInformationPage: React.FC = () => {
           listName
         })
       });
-      history.push(HOME_PAGE_URL);
+      handleUpdateLocation(HOME_PAGE_URL);
     },
     onError: async (error: HTTPError) => {
       const errorMessage = await computeErrorMessage(error, 'callout.list.delete.error', {
@@ -207,10 +215,10 @@ export const ListInformationPage: React.FC = () => {
 
   if (canUpdate) {
     buttonHandlers.edit = () => {
-      history.push(`${id}/edit`);
+      handleUpdateLocation(`${id}/edit`);
     };
     buttonHandlers.copy = () => {
-      history.push(`${id}/copy`);
+      handleUpdateLocation(`${id}/copy`);
     };
   }
 
@@ -241,12 +249,12 @@ export const ListInformationPage: React.FC = () => {
 
   const shortcuts = [
     AddCommand.duplicate(handleKeyCommand(
-      () => history.push(`${id}/copy`),
+      () => handleUpdateLocation(`${id}/copy`),
       canUpdate,
       () => showCommandError(!canUpdate)
     )),
     AddCommand.edit(handleKeyCommand(
-      () => history.push(`${id}/edit`),
+      () => handleUpdateLocation(`${id}/edit`),
       canUpdate && !isEditDisabled(conditions),
       () => showCommandError(!canUpdate)
     )),
@@ -281,7 +289,7 @@ export const ListInformationPage: React.FC = () => {
                   buttonHandlers={buttonHandlers}
                   conditions={conditions}
                 />}
-                onClose={() => history.goBack()}
+                onClose={() => handleUpdateLocation(`${HOME_PAGE_URL}`)}
                 subheader={
                   <SubHeaderBannersLayout hasBannersToDisplay={shouldShowCrossTenantWarning || showSuccessRefreshMessage}>
                     <CrossTenantListWarning shouldShow={shouldShowCrossTenantWarning} />


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UILISTS-211

Here we updated the logic of `searchParams` to store it in `URL`, to prevent problems with restoring the state of `filters` and `offset`

https://github.com/user-attachments/assets/55320583-b2da-44db-812c-7ed48a484729

