### PR TITLE
UILISTS-212: Increase the width of the record type dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,10 @@
 ## In progress
 
 * Toast messages should appear for a longer time during exports [UILISTS-210]
+* Increase the width of the record type dropdown. [UILISTS-212]
 
 [UILISTS-210]: https://folio-org.atlassian.net/browse/UILISTS-210
+[UILISTS-212]: https://folio-org.atlassian.net/browse/UILISTS-212
 
 ## [3.1.6](https://github.com/folio-org/ui-lists/tree/v3.1.6) (2025-01-23)
 

--- a/src/components/MainListInfoForm/MainListInfoForm.module.css
+++ b/src/components/MainListInfoForm/MainListInfoForm.module.css
@@ -3,7 +3,7 @@
 }
 
 .recordTypeField {
-    width: 170px;
+    width: 205px;
 }
 
 .radioLabels {


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UILISTS-212

Here we increased the size of `record type` dropdown

was: 
<img width="1507" alt="Screenshot 2025-02-05 at 04 56 41" src="https://github.com/user-attachments/assets/76b5316d-0ab4-42a4-8b37-a1bfcec3f336" />

became: 
<img width="775" alt="Screenshot 2025-02-05 at 04 55 57" src="https://github.com/user-attachments/assets/8f4ed3b4-0f3b-451a-a6e5-54743054d311" />
