### PR TITLE
UILISTS-207: Prompt for unsaved changes when we duplicate the list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@
 
 * Toast messages should appear for a longer time during exports [UILISTS-210]
 * Increase the width of the record type dropdown. [UILISTS-212]
+* Prompt for unsaved changes when we duplicate the list. [UILISTS-207]
 
 [UILISTS-210]: https://folio-org.atlassian.net/browse/UILISTS-210
 [UILISTS-212]: https://folio-org.atlassian.net/browse/UILISTS-212
+[UILISTS-207]: https://folio-org.atlassian.net/browse/UILISTS-207
 
 ## [3.1.6](https://github.com/folio-org/ui-lists/tree/v3.1.6) (2025-01-23)
 

--- a/src/hooks/useNavigationBlock/useNavigationBlock.test.ts
+++ b/src/hooks/useNavigationBlock/useNavigationBlock.test.ts
@@ -44,7 +44,10 @@ describe('useNavigationBlock', () => {
       result.current.continueNavigation();
     });
 
-    expect(pushMock).toHaveBeenCalledWith('/next');
+    expect(pushMock).toHaveBeenCalledWith({
+      pathname: '/next',
+      search: '',
+    });
     expect(result.current.showConfirmCancelEditModal).toBe(false);
   });
 

--- a/src/hooks/useNavigationBlock/useNavigationBlock.ts
+++ b/src/hooks/useNavigationBlock/useNavigationBlock.ts
@@ -18,8 +18,11 @@ export const useNavigationBlock = (
   const continueNavigation = useCallback(() => {
     if (nextLocation) {
       setShowConfirmCancelEditModal(false);
-      history.push(nextLocation.pathname + nextLocation.search);
       setIsBlocked(false);
+      history.push({
+        pathname: nextLocation.pathname,
+        search: nextLocation.search
+      });
       setNextLocation(null);
     }
   }, [history, nextLocation]);

--- a/src/pages/copylist/CopyListPage.test.tsx
+++ b/src/pages/copylist/CopyListPage.test.tsx
@@ -14,13 +14,14 @@ import listDetailsRefreshed from '../../../test/data/listDetails.Initial.json';
 import * as hooks from '../../hooks';
 
 const historyPushMock = jest.fn();
+const historyBlockMock = jest.fn();
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useParams: () => ({
     id: 'id',
   }),
-  useHistory: jest.fn(() => ({ push: historyPushMock })),
+  useHistory: jest.fn(() => ({ push: historyPushMock, block: historyBlockMock })),
 }));
 
 const renderCopyListPage = () => {

--- a/src/pages/copylist/CopyListPage.tsx
+++ b/src/pages/copylist/CopyListPage.tsx
@@ -1,4 +1,8 @@
-import React, { FC, useRef, useState } from 'react';
+import React, {
+  FC,
+  useRef,
+  useState
+} from 'react';
 import { useIntl } from 'react-intl';
 import {
   Accordion,
@@ -18,7 +22,8 @@ import {
   useInitRefresh,
   useKeyCommandsMessages,
   useListDetails,
-  useMessages, useNavigationBlock,
+  useMessages,
+  useNavigationBlock,
   useRecordTypeLabel
 } from '../../hooks';
 import { computeErrorMessage, t } from '../../services';

--- a/src/pages/editlist/EditListPage.tsx
+++ b/src/pages/editlist/EditListPage.tsx
@@ -100,11 +100,6 @@ export const EditListPage:FC = () => {
 
   const backToList = () => {
     continueNavigation();
-    const searchParams = new URLSearchParams(window.location.search).toString();
-    history.push({
-      pathname: `${HOME_PAGE_URL}/list/${id}`,
-      search: searchParams
-    });
     setIsSaving(false);
   };
 
@@ -126,7 +121,11 @@ export const EditListPage:FC = () => {
           timeout: 5999 });
         }
 
-        backToList();
+        const searchParams = new URLSearchParams(window.location.search).toString();
+        history.push({
+          pathname: `${HOME_PAGE_URL}/list/${id}`,
+          search: searchParams
+        });
       },
       onError: (error: HTTPError) => {
         (async () => {
@@ -177,6 +176,18 @@ export const EditListPage:FC = () => {
 
   const isSaveDisabled = !hasChanges || !state[FIELD_NAMES.LIST_NAME] || isLoading;
 
+  const closeHandler = () => {
+    setShowConfirmCancelEditModal(true);
+    const searchParams = new URLSearchParams(window.location.search).toString();
+    history.push(
+      {
+        pathname: `${HOME_PAGE_URL}/list/${id}`,
+        search: searchParams,
+      }
+    );
+    backToList();
+  };
+
 
   const shortcuts = [
     AddCommand.save(handleKeyCommand(
@@ -204,10 +215,7 @@ export const EditListPage:FC = () => {
         }
           isLoading={loadingListDetails}
           recordsCount={listDetails?.successRefresh?.recordsCount ?? 0}
-          onCancel={() => {
-            setShowConfirmCancelEditModal(true);
-            backToList();
-          }}
+          onCancel={closeHandler}
           onSave={onSave}
           name={listName}
           title={t('lists.edit.title', { listName })}


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UILISTS-207

We added a prompt modal for unsaved changes while duplicating the list. The navigation path was also fixed.

https://github.com/user-attachments/assets/24a1842d-4ff2-4d80-982e-eae535485443

