### PR TITLE
UILISTS-216: Unsaved changes message prompt interrupts redirect link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * migrate stripes dependencies to their Sunflower versions. [UILISTS-213]
 * migrate react-intl to v7. [UILISTS-214]
 * Hide column selection if list is inactive. [UILISTS-217]
+* Unsaved changes message prompt interrupts redirect link. [UILISTS-216]
 
 [UILISTS-210]: https://folio-org.atlassian.net/browse/UILISTS-210
 [UILISTS-212]: https://folio-org.atlassian.net/browse/UILISTS-212
@@ -15,6 +16,7 @@
 [UILISTS-213]: https://folio-org.atlassian.net/browse/UILISTS-213
 [UILISTS-214]: https://folio-org.atlassian.net/browse/UILISTS-214
 [UILISTS-217]: https://folio-org.atlassian.net/browse/UILISTS-217
+[UILISTS-216]: https://folio-org.atlassian.net/browse/UILISTS-216
 
 ## [3.1.6](https://github.com/folio-org/ui-lists/tree/v3.1.6) (2025-01-23)
 

--- a/src/pages/createlist/CreateListPage.tsx
+++ b/src/pages/createlist/CreateListPage.tsx
@@ -10,7 +10,7 @@ import {
   useMessages,
   useRecordTypes,
   useCreateList,
-  useKeyCommandsMessages
+  useKeyCommandsMessages, useNavigationBlock
 } from '../../hooks';
 import { CreateListLayout, MainCreateListForm } from './components';
 import { HasCommandWrapper } from '../../components';
@@ -28,6 +28,13 @@ export const CreateListPage:FC = () => {
   const { isLoading: isLoadingRecords, recordTypes = [] } = useRecordTypes();
   const { showSuccessMessage, showErrorMessage } = useMessages();
   const { showCommandError } = useKeyCommandsMessages();
+
+  const {
+    showConfirmCancelEditModal,
+    continueNavigation,
+    keepEditHandler,
+    setShowConfirmCancelEditModal
+  } = useNavigationBlock(hasChanges);
 
   const { saveList, isLoading } = useCreateList({
     listObject: state,
@@ -47,6 +54,7 @@ export const CreateListPage:FC = () => {
         }) });
 
         history.push(`list/${list?.id}`);
+        continueNavigation();
       }
     }
   });
@@ -87,8 +95,12 @@ export const CreateListPage:FC = () => {
           isSaveButtonDisabled={isSaveDisabled}
           onSave={saveList}
           onClose={closeViewHandler}
-          onCancel={closeViewHandler}
           showModalOnCancel={hasChanges}
+          showConfirmCancelEditModal={showConfirmCancelEditModal}
+          keepEditHandler={keepEditHandler}
+          setShowConfirmCancelEditModal={setShowConfirmCancelEditModal}
+          continueNavigation={continueNavigation}
+          onCancel={closeViewHandler}
         >
           <MainCreateListForm
             selectedType={recordType}

--- a/src/pages/createlist/components/CreateListLayout/CreateListLayout.tsx
+++ b/src/pages/createlist/components/CreateListLayout/CreateListLayout.tsx
@@ -3,42 +3,41 @@ import { useIntl } from 'react-intl';
 import { Layer, Loading, Pane, PaneFooter, Paneset } from '@folio/stripes/components';
 import { CancelEditModal, ListAppIcon, Buttons } from '../../../../components';
 import { t, tString } from '../../../../services';
-import { useNavigationBlock } from '../../../../hooks';
 
 type CreateListLayoutProps = {
     isSaveButtonDisabled?: boolean;
     isSavingInProgress?: boolean;
-    onCancel?: () => void;
     onSave?: () => void;
     onClose?: () => void;
     showModalOnCancel?: boolean;
     children?: ReactElement;
+    showConfirmCancelEditModal: boolean;
+    keepEditHandler: ()=> void;
+    setShowConfirmCancelEditModal: (value: boolean)=> void;
+    continueNavigation: ()=> void;
+    onCancel: ()=> void;
 };
 
 export const CreateListLayout: FC<CreateListLayoutProps> = ({
   isSaveButtonDisabled = false,
   isSavingInProgress = false,
-  onCancel = () => {},
   onSave = () => {},
   onClose = () => {},
   showModalOnCancel = false,
-  children
+  children,
+  showConfirmCancelEditModal = false,
+  keepEditHandler,
+  setShowConfirmCancelEditModal,
+  continueNavigation,
+  onCancel
 }) => {
   const intl = useIntl();
-
-  const {
-    showConfirmCancelEditModal,
-    continueNavigation,
-    keepEditHandler,
-    setShowConfirmCancelEditModal
-  } = useNavigationBlock(showModalOnCancel);
 
   const cancelHandler = () => {
     if (!showConfirmCancelEditModal) {
       setShowConfirmCancelEditModal(true);
     }
     continueNavigation();
-    onCancel();
   };
 
   return (
@@ -61,7 +60,12 @@ export const CreateListLayout: FC<CreateListLayoutProps> = ({
             footer={
               <PaneFooter
                 renderStart={
-                  <Buttons.Cancel onCancel={cancelHandler} />
+                  <Buttons.Cancel onCancel={() => {
+                    onCancel();
+                    cancelHandler();
+                  }
+                  }
+                  />
                                 }
                 renderEnd={
                   <Buttons.Save

--- a/src/pages/createlist/components/CreateListLayout/tests/CreateListLayout.test.tsx
+++ b/src/pages/createlist/components/CreateListLayout/tests/CreateListLayout.test.tsx
@@ -4,6 +4,11 @@ import { jest } from '@jest/globals';
 import React from 'react';
 import { CreateListLayout } from '../CreateListLayout';
 
+const onCancelMock = jest.fn();
+const keepEditHandlerMock = jest.fn();
+const setShowConfirmCancelEditModalMock = jest.fn();
+const continueNavigationMock = jest.fn();
+
 describe('CreateListLayout', () => {
   test('Expected to call onClose function when user click on close button', async () => {
     const onCloseHandlerMock = jest.fn();
@@ -11,6 +16,11 @@ describe('CreateListLayout', () => {
     const configuredComponent = (
       <CreateListLayout
         onClose={onCloseHandlerMock}
+        onCancel={onCancelMock}
+        keepEditHandler={keepEditHandlerMock}
+        showConfirmCancelEditModal={false}
+        setShowConfirmCancelEditModal={setShowConfirmCancelEditModalMock}
+        continueNavigation={continueNavigationMock}
       >
         <h1>Main</h1>
       </CreateListLayout>
@@ -29,7 +39,13 @@ describe('CreateListLayout', () => {
 
   test('Expected to render main content', () => {
     const configuredComponent = (
-      <CreateListLayout>
+      <CreateListLayout
+        onCancel={onCancelMock}
+        keepEditHandler={keepEditHandlerMock}
+        showConfirmCancelEditModal={false}
+        setShowConfirmCancelEditModal={setShowConfirmCancelEditModalMock}
+        continueNavigation={continueNavigationMock}
+      >
         <span>Main content</span>
       </CreateListLayout>
     );
@@ -42,10 +58,13 @@ describe('CreateListLayout', () => {
   });
 
   test('Expected to render cancel button', async () => {
-    const onCancelMock = jest.fn();
     const configuredComponent = (
       <CreateListLayout
         onCancel={onCancelMock}
+        keepEditHandler={keepEditHandlerMock}
+        showConfirmCancelEditModal={false}
+        setShowConfirmCancelEditModal={setShowConfirmCancelEditModalMock}
+        continueNavigation={continueNavigationMock}
       >
         <section>Main</section>
       </CreateListLayout>
@@ -66,6 +85,11 @@ describe('CreateListLayout', () => {
     const configuredComponent = (
       <CreateListLayout
         onSave={onSaveMock}
+        showConfirmCancelEditModal={false}
+        onCancel={onCancelMock}
+        keepEditHandler={keepEditHandlerMock}
+        setShowConfirmCancelEditModal={setShowConfirmCancelEditModalMock}
+        continueNavigation={continueNavigationMock}
       >
         <section>Main</section>
       </CreateListLayout>
@@ -83,6 +107,11 @@ describe('CreateListLayout', () => {
   test('Expected to disable save button when isSaveButtonDisabled passed', async () => {
     const configuredComponent = (
       <CreateListLayout
+        onCancel={onCancelMock}
+        showConfirmCancelEditModal={false}
+        keepEditHandler={keepEditHandlerMock}
+        setShowConfirmCancelEditModal={setShowConfirmCancelEditModalMock}
+        continueNavigation={continueNavigationMock}
         isSaveButtonDisabled
       >
         <section>Main</section>
@@ -100,6 +129,11 @@ describe('CreateListLayout', () => {
     const configuredComponent = (
       <CreateListLayout
         isSavingInProgress
+        showConfirmCancelEditModal={false}
+        onCancel={onCancelMock}
+        keepEditHandler={keepEditHandlerMock}
+        setShowConfirmCancelEditModal={setShowConfirmCancelEditModalMock}
+        continueNavigation={continueNavigationMock}
       >
         <section>Main</section>
       </CreateListLayout>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UILISTS-216

We fixed the prompt for unsaved changes for the create list flow.