### PR TITLE
UILISTS-228: Display a meaningfull error text when the POST /lists is failing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## In progress
 
+* Display a meaningfull error text when the POST /lists is failing. [UILISTS-228]
+
+[UILISTS-228]: https://folio-org.atlassian.net/browse/UILISTS-228
+
 ## [4.0.0](https://github.com/folio-org/ui-lists/tree/v4.0.0) (2025-03-13)
 
 * Toast messages should appear for a longer time during exports [UILISTS-210]

--- a/translations/ui-lists/en.json
+++ b/translations/ui-lists/en.json
@@ -205,5 +205,6 @@
 
   "unexpected.error": "Unable to complete action. Query is no longer valid due to a deleted field(s). Please edit the list query or delete the list.",
   "update-fql.query.invalid": "Unable to complete action. Query is no longer valid due to a deleted field(s). Please edit the list query or delete the list.",
-  "create-fql.query.invalid": "Unable to complete action. Query is no longer valid due to a deleted field(s). Please edit the list query or delete the list."
+  "create-fql.query.invalid": "Unable to complete action. Query is no longer valid due to a deleted field(s). Please edit the list query or delete the list.",
+  "unhandled.error": "An error occurred."
 }


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UILISTS-228

Here we add translation for the error `POST /lists`