### PR TITLE
UILISTS-220: Make toast message for failed export so it doesn't disappear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## In progress
 
+* Make toast message for failed export it doesn't disappear [UILISTS-220]
+
+[UILISTS-220]: https://folio-org.atlassian.net/browse/UILISTS-220
+
 ## [4.0.0](https://github.com/folio-org/ui-lists/tree/v4.0.0) (2025-03-13)
 
 * Toast messages should appear for a longer time during exports [UILISTS-210]

--- a/src/hooks/useCSVListExport/useCSVExport.tsx
+++ b/src/hooks/useCSVListExport/useCSVExport.tsx
@@ -52,7 +52,7 @@ export const useCSVExport = ({ listId, listName, listDetails, columns }: { listI
     onError: async (error: HTTPError) => {
       const errorMessage = await computeErrorMessage(error, 'callout.list.csv-export.error', { listName });
 
-      showErrorMessage({ message: errorMessage, timeout: MESSAGE_DELAY });
+      showErrorMessage({ message: errorMessage, timeout: Infinity });
 
       removeListFromStorage();
     },

--- a/src/hooks/useCSVListExport/useCSVExportPolling.tsx
+++ b/src/hooks/useCSVListExport/useCSVExportPolling.tsx
@@ -18,7 +18,7 @@ export const useCSVExportPolling = (listName: string, clearStorage: () => void) 
 
           if (isFailed(status)) {
             showErrorMessage({
-              timeout: MESSAGE_DELAY,
+              timeout: Infinity,
               message: t('callout.list.csv-export.error', {
                 listName
               })
@@ -41,7 +41,7 @@ export const useCSVExportPolling = (listName: string, clearStorage: () => void) 
               },
               onError: () => {
                 showErrorMessage({
-                  timeout: MESSAGE_DELAY,
+                  timeout: Infinity,
                   message: t('callout.list.csv-export.error', {
                     listName
                   })


### PR DESCRIPTION
[UILISTS-220](https://folio-org.atlassian.net/browse/UILISTS-220)

Here we increased the time for the error toast for an unlimited time, till the user dismisses the toast