### PR TITLE
[UILISTS-222] Prevent incorrectly showing unsaved changes prompt on edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,10 @@
 ## In progress
 
 * Display a meaningfull error text when the POST /lists is failing. [UILISTS-228]
+* Prevent incorrectly showing unsaved changes prompt when using the query builder after editing a list. [UILISTS-222]
 
 [UILISTS-228]: https://folio-org.atlassian.net/browse/UILISTS-228
+[UILISTS-222]: https://folio-org.atlassian.net/browse/UILISTS-222
 
 ## [4.0.0](https://github.com/folio-org/ui-lists/tree/v4.0.0) (2025-03-13)
 

--- a/src/components/ConfigureQuery/ConfigureQuery.tsx
+++ b/src/components/ConfigureQuery/ConfigureQuery.tsx
@@ -28,6 +28,7 @@ export interface ConfigureQueryProps {
   version?: number;
   recordColumns?: string[];
   initialValues?: Record<string, unknown>;
+  setIsModalShown?: (isShown: boolean) => void;
 }
 
 export const ConfigureQuery: FC<ConfigureQueryProps> = ({
@@ -42,6 +43,7 @@ export const ConfigureQuery: FC<ConfigureQueryProps> = ({
   version,
   recordColumns,
   initialValues,
+  setIsModalShown = () => ({}),
 }) => {
   const history = useHistory();
   const ky = useOkapiKy();
@@ -71,11 +73,7 @@ export const ConfigureQuery: FC<ConfigureQueryProps> = ({
       limit,
     };
 
-    try {
-      return await ky.get(`query/${queryId}`, { searchParams }).json();
-    } catch (error) {
-      throw error;
-    }
+    return ky.get(`query/${queryId}`, { searchParams }).json();
   };
 
   const testQueryDataSource = async ({ fqlQuery }: { fqlQuery: FqlQuery }) => {
@@ -176,6 +174,7 @@ export const ConfigureQuery: FC<ConfigureQueryProps> = ({
       recordsLimit={recordsLimit}
       saveBtnLabel={t('list.modal.run-query-and-save')}
       triggerButtonLabel={triggerButtonLabel}
+      setIsModalShown={setIsModalShown}
     />
   );
 };

--- a/src/components/EditListResultViewer/EditListResultViewer.tsx
+++ b/src/components/EditListResultViewer/EditListResultViewer.tsx
@@ -23,6 +23,7 @@ export interface EditListResultViewerProps {
   isDuplicating?: boolean;
   isQueryButtonDisabled?: boolean;
   setColumns?: (columns: QueryBuilderColumnMetadata[]) => void;
+  setIsModalShown?: (isShown: boolean) => void;
 }
 
 export const EditListResultViewer: FC<EditListResultViewerProps> = ({
@@ -40,6 +41,7 @@ export const EditListResultViewer: FC<EditListResultViewerProps> = ({
   setColumns,
   isDuplicating = false,
   isQueryButtonDisabled = false,
+  setIsModalShown,
 }) => {
   const ky = useOkapiKy();
 
@@ -90,6 +92,7 @@ export const EditListResultViewer: FC<EditListResultViewerProps> = ({
                 : VISIBILITY_VALUES.PRIVATE
             }
             description={description}
+            setIsModalShown={setIsModalShown}
           />
         </div>
       }

--- a/src/pages/editlist/EditListPage.tsx
+++ b/src/pages/editlist/EditListPage.tsx
@@ -19,7 +19,8 @@ import {
   useDeleteList,
   useKeyCommandsMessages,
   useListDetails,
-  useMessages, useNavigationBlock,
+  useMessages,
+  useNavigationBlock,
   useRecordTypeLabel
 } from '../../hooks';
 import { t, computeErrorMessage, isInactive, isInDraft, isCanned, isEmptyList } from '../../services';
@@ -49,6 +50,7 @@ export const EditListPage:FC = () => {
   const { id }: { id: string } = useParams();
   const [columns, setColumns] = useState<QueryBuilderColumnMetadata[]>([]);
   const [isSaving, setIsSaving] = useState(false);
+  const [isQueryBuilderOpen, setIsQueryBuilderOpen] = useState(false);
 
   const { data: listDetails, isLoading: loadingListDetails, detailsError } = useListDetails(id);
   const { showCommandError } = useKeyCommandsMessages();
@@ -91,12 +93,14 @@ export const EditListPage:FC = () => {
 
   const version = listDetails?.version ?? 0;
 
+  // we only want to show the modal when we have form changes and the QB has not been invoked.
+  // if the QB is invoked, its own test/run query and save will handle saving, not us.
   const {
     showConfirmCancelEditModal,
     continueNavigation,
     keepEditHandler,
     setShowConfirmCancelEditModal
-  } = useNavigationBlock(hasChanges, isSaving, true);
+  } = useNavigationBlock(hasChanges && !isQueryBuilderOpen, isSaving, true);
 
   const backToList = () => {
     continueNavigation();
@@ -263,6 +267,9 @@ export const EditListPage:FC = () => {
               visibility={state[FIELD_NAMES.VISIBILITY]}
               description={state[FIELD_NAMES.DESCRIPTION]}
               setColumns={setColumns}
+              // QB will save the description/name/etc; we just need to turn off the "there are unsaved changes"
+              // dialog when the QB closes
+              setIsModalShown={setIsQueryBuilderOpen}
             />
           </AccordionStatus>
           <CancelEditModal


### PR DESCRIPTION
Relies on https://github.com/folio-org/ui-plugin-query-builder/pull/235; see explanation there.