### PR TITLE
[UILISTS-223] Rely on ui-plugin-query-builder for user-friendly queries

### DIFF
--- a/src/hooks/useQueryBuilderSources/index.ts
+++ b/src/hooks/useQueryBuilderSources/index.ts
@@ -1,0 +1,1 @@
+export * from './useQueryBuilderSources';

--- a/src/hooks/useQueryBuilderSources/useQueryBuilderSources.ts
+++ b/src/hooks/useQueryBuilderSources/useQueryBuilderSources.ts
@@ -1,0 +1,88 @@
+import { useOkapiKy } from '@folio/stripes/core';
+import { useCallback } from 'react';
+import { FqlQuery } from '../../interfaces';
+
+export function useQueryBuilderCommonSources(entityTypeId: string | undefined) {
+  const ky = useOkapiKy();
+
+  return {
+    entityTypeDataSource: useCallback(
+      () => (entityTypeId ? ky.get(`entity-types/${entityTypeId}`).json() : undefined),
+      [ky, entityTypeId],
+    ),
+
+    testQueryDataSource: useCallback(
+      ({ fqlQuery }: { fqlQuery: FqlQuery }) => {
+        return ky
+          .post('query', {
+            json: {
+              entityTypeId,
+              fqlQuery: JSON.stringify(fqlQuery),
+            },
+          })
+          .json();
+      },
+      [ky, entityTypeId],
+    ),
+
+    queryDetailsDataSource: useCallback(
+      ({
+        queryId,
+        includeContent,
+        offset,
+        limit,
+      }: {
+        queryId: string;
+        includeContent: boolean;
+        offset: number;
+        limit: number;
+      }) => {
+        return ky
+          .get(`query/${queryId}`, {
+            searchParams: {
+              includeResults: includeContent,
+              offset,
+              limit,
+            },
+          })
+          .json();
+      },
+      [ky],
+    ),
+
+    getParamsSource: useCallback(
+      (p: { entityTypeId: string; columnName: string; searchValue: string }) => {
+        return ky
+          .get(`entity-types/${p.entityTypeId}/columns/${p.columnName}/values`, {
+            searchParams: {
+              search: p.searchValue,
+            },
+          })
+          .json();
+      },
+      [ky],
+    ),
+  };
+}
+
+export function useQueryBuilderResultViewerSources(
+  entityTypeId: string | undefined,
+  listId: string,
+  visibleColumns: string[] | null,
+) {
+  const ky = useOkapiKy();
+
+  return {
+    ...useQueryBuilderCommonSources(entityTypeId),
+    contentDataSource: useCallback(
+      ({ limit, offset }: { limit: number; offset: number }) => {
+        return ky
+          .get(
+            `lists/${listId}/contents?offset=${offset}&size=${limit}&fields=${visibleColumns?.join(',')}`,
+          )
+          .json();
+      },
+      [ky, listId, visibleColumns],
+    ),
+  };
+}

--- a/src/pages/copylist/CopyListPage.tsx
+++ b/src/pages/copylist/CopyListPage.tsx
@@ -39,7 +39,7 @@ import { useCopyListFormState } from './hooks';
 import { FIELD_NAMES, ListsRecordBase, STATUS_VALUES } from '../../interfaces';
 import { HOME_PAGE_URL } from '../../constants';
 import { AddCommand } from '../../keyboard-shortcuts';
-import { handleKeyCommand, removeBackslashes } from '../../utils';
+import { handleKeyCommand } from '../../utils';
 
 export const CopyListPage:FC = () => {
   const history = useHistory();
@@ -186,7 +186,6 @@ export const CopyListPage:FC = () => {
               version={listDetails?.version}
               fields={listDetails?.fields}
               fqlQuery={listDetails?.fqlQuery ?? ''}
-              userFriendlyQuery={removeBackslashes(listDetails?.userFriendlyQuery)}
               contentVersion={listDetails?.successRefresh?.contentVersion ?? 0}
               entityTypeId={listDetails?.entityTypeId}
               status={state[FIELD_NAMES.STATUS]}

--- a/src/pages/editlist/EditListPage.tsx
+++ b/src/pages/editlist/EditListPage.tsx
@@ -39,7 +39,7 @@ import { useEditListFormState, useEditList } from './hooks';
 import { FIELD_NAMES, QueryBuilderColumnMetadata } from '../../interfaces';
 import { HOME_PAGE_URL } from '../../constants';
 import { AddCommand } from '../../keyboard-shortcuts';
-import { handleKeyCommand, removeBackslashes } from '../../utils';
+import { handleKeyCommand } from '../../utils';
 
 
 export const EditListPage:FC = () => {
@@ -259,7 +259,6 @@ export const EditListPage:FC = () => {
               version={version}
               fields={listDetails?.fields || []}
               fqlQuery={listDetails?.fqlQuery ?? ''}
-              userFriendlyQuery={removeBackslashes(listDetails?.userFriendlyQuery)}
               contentVersion={listDetails?.successRefresh?.contentVersion ?? 0}
               entityTypeId={listDetails?.entityTypeId ?? ''}
               status={state[FIELD_NAMES.STATUS]}

--- a/src/pages/listInformation/ListInformationPage.tsx
+++ b/src/pages/listInformation/ListInformationPage.tsx
@@ -54,7 +54,7 @@ import {
   ErrorComponent,
   HasCommandWrapper
 } from '../../components';
-import { handleKeyCommand, removeBackslashes } from '../../utils';
+import { handleKeyCommand } from '../../utils';
 import { AddCommand } from '../../keyboard-shortcuts';
 
 export const ListInformationPage: React.FC = () => {
@@ -309,8 +309,8 @@ export const ListInformationPage: React.FC = () => {
                   <AccordionSet>
                     <ListInformationResultViewer
                       refreshInProgress={isRefreshInProgress}
-                      listID={listData?.id}
-                      userFriendlyQuery={removeBackslashes(listData?.userFriendlyQuery)}
+                      listId={listData?.id}
+                      fqlQuery={listData?.fqlQuery}
                       entityTypeId={listData?.entityTypeId}
                       refreshTrigger={Number(refreshTrigger)}
                       setColumnControlList={setColumnControls}

--- a/src/pages/listInformation/components/ListInformationResultViewer/ListInformationResultViewer.tsx
+++ b/src/pages/listInformation/components/ListInformationResultViewer/ListInformationResultViewer.tsx
@@ -1,62 +1,50 @@
-import React from 'react';
-// @ts-ignore:next-line
-import { Pluggable, useOkapiKy } from '@folio/stripes/core';
-import { t } from '../../../../services';
+import { Loading } from '@folio/stripes/components';
+import { Pluggable } from '@folio/stripes/core';
+import React, { useMemo } from 'react';
+import { useQueryBuilderResultViewerSources } from '../../../../hooks/useQueryBuilderSources';
 import { QueryBuilderColumnMetadata } from '../../../../interfaces';
-import { removeBackslashes } from '../../../../utils';
+import { t } from '../../../../services';
 
 type ListInformationResultViewerType = {
-  userFriendlyQuery?: string;
   refreshTrigger?: number | boolean;
   setColumnControlList?: (columns: QueryBuilderColumnMetadata[]) => void;
   setDefaultVisibleColumns?: (columns: string[]) => void;
-  listID?: string;
+  listId?: string;
+  fqlQuery?: string;
   entityTypeId?: string;
   visibleColumns?: string[] | null;
   refreshInProgress: boolean;
 };
 
-
 export const ListInformationResultViewer: React.FC<ListInformationResultViewerType> = ({
-  userFriendlyQuery = '',
   refreshTrigger = 0,
   setColumnControlList = () => {},
-  listID = '',
+  listId = '',
+  fqlQuery,
   entityTypeId = '',
   setDefaultVisibleColumns = () => {},
   visibleColumns = [],
-  refreshInProgress
+  refreshInProgress,
 }) => {
-  const ky = useOkapiKy();
-
-  const getAsyncContentData = ({ limit, offset }: any) => {
-    return ky.get(`lists/${listID}/contents?offset=${offset}&size=${limit}&fields=${visibleColumns?.join(',')}`).json();
-  };
-
-  const getAsyncEntityType = () => {
-    return ky.get(`entity-types/${entityTypeId}`).json();
-  };
+  const fqlQueryParsed = useMemo(() => (fqlQuery ? JSON.parse(fqlQuery) : undefined), [fqlQuery]);
 
   return (
     <Pluggable
       type="query-builder"
       componentType="viewer"
-      accordionHeadline={
-        t('accordion.title.query',
-          { query: removeBackslashes(userFriendlyQuery) })}
-      headline={({ totalRecords }: any) => t('mainPane.subTitle',
-        { count: totalRecords === 'NaN' ? 0 : totalRecords })}
+      showQueryAccordion
+      fqlQuery={fqlQueryParsed}
+      headline={({ totalRecords }: any) => t('mainPane.subTitle', { count: totalRecords === 'NaN' ? 0 : totalRecords })}
       refreshInProgress={refreshInProgress}
       refreshTrigger={refreshTrigger}
-      contentDataSource={getAsyncContentData}
-      entityTypeDataSource={getAsyncEntityType}
+      {...useQueryBuilderResultViewerSources(entityTypeId, listId, visibleColumns)}
       visibleColumns={visibleColumns}
       onSetDefaultVisibleColumns={setDefaultVisibleColumns}
       onSetDefaultColumns={setColumnControlList}
       height={500}
       contentQueryKeys={visibleColumns}
     >
-      No loaded
+      <Loading />
     </Pluggable>
   );
 };

--- a/src/utils/helpers.test.ts
+++ b/src/utils/helpers.test.ts
@@ -1,5 +1,5 @@
 import { expect } from '@jest/globals';
-import { buildListsUrl, filterByIncludes, handleKeyCommand, removeBackslashes } from './helpers';
+import { buildListsUrl, filterByIncludes, handleKeyCommand } from './helpers';
 import { STATUS_ACTIVE, STATUS_INACTIVE, VISIBILITY_PRIVATE, VISIBILITY_SHARED } from './constants';
 
 const baseUrl = 'http://www.test.com';
@@ -120,32 +120,6 @@ describe('Helpers', () => {
 
       expect(callback).not.toBeCalled();
       expect(preventDefault).toBeCalled();
-    });
-
-    describe('removeBackslashes', () => {
-      it('should remove all single backslashes from a string', () => {
-        expect(removeBackslashes('Wierd test \\/\\/\\/ \\*\\* symbols \\)\\)\\)')).toBe('Wierd test /// ** symbols )))');
-      });
-
-      it('should return the same string if no backslashes are present', () => {
-        expect(removeBackslashes('No backslashes here')).toBe('No backslashes here');
-      });
-
-      it('should handle strings with double backslashes', () => {
-        expect(removeBackslashes('Double backslashes here: \\...')).toBe('Double backslashes here: ...');
-      });
-
-      it('should handle strings with multiple backslashes in a row', () => {
-        expect(removeBackslashes('Multiple backslashes: \\\\\\\\\\')).toBe('Multiple backslashes: \\\\\\');
-      });
-
-      it('should handle an empty string', () => {
-        expect(removeBackslashes('')).toBe('');
-      });
-
-      it('should return empty string if input is undefined', () => {
-        expect(removeBackslashes()).toBe('');
-      });
     });
   });
 });

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -97,7 +97,3 @@ export const handleKeyCommand = (
     }
   };
 };
-
-export const removeBackslashes = (str = '') => {
-  return str.replace(/\\(.)/g, '$1');
-};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,7 +6,6 @@ export {
   filterByIncludes,
   getStatusButtonElem,
   handleKeyCommand,
-  removeBackslashes,
 } from './helpers';
 
 export { USER_PERMS } from './constants';

--- a/translations/ui-lists/ar.json
+++ b/translations/ui-lists/ar.json
@@ -31,7 +31,6 @@
     "list.info.source": "المصدر",
     "list.info.source.system": "النظام",
     "accordion.title.list-information": "List information",
-    "accordion.title.query": "Query: {query}",
     "pane.dropdown.show-columns": "عرض الأعمدة",
     "pane.dropdown.refresh": "Refresh list",
     "pane.dropdown.cancel-refresh": "Cancel refresh",

--- a/translations/ui-lists/ber.json
+++ b/translations/ui-lists/ber.json
@@ -31,7 +31,6 @@
     "list.info.source": "Source",
     "list.info.source.system": "System",
     "accordion.title.list-information": "List information",
-    "accordion.title.query": "Query: {query}",
     "pane.dropdown.show-columns": "Show columns",
     "pane.dropdown.refresh": "Refresh list",
     "pane.dropdown.cancel-refresh": "Cancel refresh",

--- a/translations/ui-lists/ca.json
+++ b/translations/ui-lists/ca.json
@@ -31,7 +31,6 @@
     "list.info.source": "Font",
     "list.info.source.system": "System",
     "accordion.title.list-information": "List information",
-    "accordion.title.query": "Query: {query}",
     "pane.dropdown.show-columns": "Show columns",
     "pane.dropdown.refresh": "Refresh list",
     "pane.dropdown.cancel-refresh": "Cancel refresh",

--- a/translations/ui-lists/da.json
+++ b/translations/ui-lists/da.json
@@ -31,7 +31,6 @@
     "list.info.source": "Source",
     "list.info.source.system": "System",
     "accordion.title.list-information": "List information",
-    "accordion.title.query": "Query: {query}",
     "pane.dropdown.show-columns": "Show columns",
     "pane.dropdown.refresh": "Refresh list",
     "pane.dropdown.cancel-refresh": "Cancel refresh",

--- a/translations/ui-lists/de.json
+++ b/translations/ui-lists/de.json
@@ -31,7 +31,6 @@
     "list.info.source": "Quelle",
     "list.info.source.system": "System",
     "accordion.title.list-information": "List information",
-    "accordion.title.query": "Query: {query}",
     "pane.dropdown.show-columns": "Spalten anzeigen",
     "pane.dropdown.refresh": "Refresh list",
     "pane.dropdown.cancel-refresh": "Cancel refresh",

--- a/translations/ui-lists/en.json
+++ b/translations/ui-lists/en.json
@@ -36,11 +36,9 @@
   "list.info.source": "Source",
   "list.info.record-type": "Record type",
 
-
   "list.info.source.system": "System",
 
   "accordion.title.list-information": "List information",
-  "accordion.title.query": "Query: {query}",
 
   "pane.dropdown.available-permissions": "Available permissions",
 

--- a/translations/ui-lists/en_GB.json
+++ b/translations/ui-lists/en_GB.json
@@ -31,7 +31,6 @@
     "list.info.source": "Source",
     "list.info.source.system": "System",
     "accordion.title.list-information": "List information",
-    "accordion.title.query": "Query: {query}",
     "pane.dropdown.show-columns": "Show columns",
     "pane.dropdown.refresh": "Refresh list",
     "pane.dropdown.cancel-refresh": "Cancel refresh",

--- a/translations/ui-lists/en_SE.json
+++ b/translations/ui-lists/en_SE.json
@@ -31,7 +31,6 @@
     "list.info.source": "Source",
     "list.info.source.system": "System",
     "accordion.title.list-information": "List information",
-    "accordion.title.query": "Query: {query}",
     "pane.dropdown.show-columns": "Show columns",
     "pane.dropdown.refresh": "Refresh list",
     "pane.dropdown.cancel-refresh": "Cancel refresh",

--- a/translations/ui-lists/en_US.json
+++ b/translations/ui-lists/en_US.json
@@ -31,7 +31,6 @@
     "list.info.source": "Source",
     "list.info.source.system": "System",
     "accordion.title.list-information": "List information",
-    "accordion.title.query": "Query: {query}",
     "pane.dropdown.show-columns": "Show columns",
     "pane.dropdown.refresh": "Refresh list",
     "pane.dropdown.cancel-refresh": "Cancel refresh",

--- a/translations/ui-lists/fr.json
+++ b/translations/ui-lists/fr.json
@@ -31,7 +31,6 @@
     "list.info.source": "Source",
     "list.info.source.system": "System",
     "accordion.title.list-information": "List information",
-    "accordion.title.query": "Query: {query}",
     "pane.dropdown.show-columns": "Afficher les colonnes",
     "pane.dropdown.refresh": "Refresh list",
     "pane.dropdown.cancel-refresh": "Cancel refresh",

--- a/translations/ui-lists/fr_FR.json
+++ b/translations/ui-lists/fr_FR.json
@@ -31,7 +31,6 @@
     "list.info.source": "Source",
     "list.info.source.system": "Système",
     "accordion.title.list-information": "List information",
-    "accordion.title.query": "Query: {query}",
     "pane.dropdown.show-columns": "Afficher les colonnes",
     "pane.dropdown.refresh": "Refresh list",
     "pane.dropdown.cancel-refresh": "Cancel refresh",

--- a/translations/ui-lists/he.json
+++ b/translations/ui-lists/he.json
@@ -31,7 +31,6 @@
     "list.info.source": "Source",
     "list.info.source.system": "System",
     "accordion.title.list-information": "List information",
-    "accordion.title.query": "Query: {query}",
     "pane.dropdown.show-columns": "Show columns",
     "pane.dropdown.refresh": "Refresh list",
     "pane.dropdown.cancel-refresh": "Cancel refresh",

--- a/translations/ui-lists/hi_IN.json
+++ b/translations/ui-lists/hi_IN.json
@@ -31,7 +31,6 @@
     "list.info.source": "Source",
     "list.info.source.system": "System",
     "accordion.title.list-information": "List information",
-    "accordion.title.query": "Query: {query}",
     "pane.dropdown.show-columns": "Show columns",
     "pane.dropdown.refresh": "Refresh list",
     "pane.dropdown.cancel-refresh": "Cancel refresh",

--- a/translations/ui-lists/hu.json
+++ b/translations/ui-lists/hu.json
@@ -31,7 +31,6 @@
     "list.info.source": "Forrás",
     "list.info.source.system": "System",
     "accordion.title.list-information": "List information",
-    "accordion.title.query": "Query: {query}",
     "pane.dropdown.show-columns": "Show columns",
     "pane.dropdown.refresh": "Refresh list",
     "pane.dropdown.cancel-refresh": "Cancel refresh",

--- a/translations/ui-lists/it_IT.json
+++ b/translations/ui-lists/it_IT.json
@@ -31,7 +31,6 @@
     "list.info.source": "Fonte",
     "list.info.source.system": "Sistema",
     "accordion.title.list-information": "List information",
-    "accordion.title.query": "Query: {query}",
     "pane.dropdown.show-columns": "Show columns",
     "pane.dropdown.refresh": "Refresh list",
     "pane.dropdown.cancel-refresh": "Cancel refresh",

--- a/translations/ui-lists/ko.json
+++ b/translations/ui-lists/ko.json
@@ -31,7 +31,6 @@
     "list.info.source": "출처",
     "list.info.source.system": "시스템",
     "accordion.title.list-information": "List information",
-    "accordion.title.query": "Query: {query}",
     "pane.dropdown.show-columns": "열 표시",
     "pane.dropdown.refresh": "Refresh list",
     "pane.dropdown.cancel-refresh": "Cancel refresh",

--- a/translations/ui-lists/nb.json
+++ b/translations/ui-lists/nb.json
@@ -31,7 +31,6 @@
     "list.info.source": "Source",
     "list.info.source.system": "System",
     "accordion.title.list-information": "List information",
-    "accordion.title.query": "Query: {query}",
     "pane.dropdown.show-columns": "Show columns",
     "pane.dropdown.refresh": "Refresh list",
     "pane.dropdown.cancel-refresh": "Cancel refresh",

--- a/translations/ui-lists/nl.json
+++ b/translations/ui-lists/nl.json
@@ -31,7 +31,6 @@
     "list.info.source": "Bron",
     "list.info.source.system": "Systeem",
     "accordion.title.list-information": "Lijstinformatie",
-    "accordion.title.query": "Query: {query}",
     "pane.dropdown.show-columns": "Kolommen weergeven",
     "pane.dropdown.refresh": "Lijst verversen",
     "pane.dropdown.cancel-refresh": "Verversen annuleren",

--- a/translations/ui-lists/nn.json
+++ b/translations/ui-lists/nn.json
@@ -31,7 +31,6 @@
     "list.info.source": "Source",
     "list.info.source.system": "System",
     "accordion.title.list-information": "List information",
-    "accordion.title.query": "Query: {query}",
     "pane.dropdown.show-columns": "Show columns",
     "pane.dropdown.refresh": "Refresh list",
     "pane.dropdown.cancel-refresh": "Cancel refresh",

--- a/translations/ui-lists/pl.json
+++ b/translations/ui-lists/pl.json
@@ -31,7 +31,6 @@
     "list.info.source": "Źródło",
     "list.info.source.system": "System",
     "accordion.title.list-information": "List information",
-    "accordion.title.query": "Query: {query}",
     "pane.dropdown.show-columns": "Pokaż kolumny",
     "pane.dropdown.refresh": "Refresh list",
     "pane.dropdown.cancel-refresh": "Cancel refresh",

--- a/translations/ui-lists/pt_PT.json
+++ b/translations/ui-lists/pt_PT.json
@@ -31,7 +31,6 @@
     "list.info.source": "Fonte",
     "list.info.source.system": "Sistema",
     "accordion.title.list-information": "List information",
-    "accordion.title.query": "Query: {query}",
     "pane.dropdown.show-columns": "Show columns",
     "pane.dropdown.refresh": "Refresh list",
     "pane.dropdown.cancel-refresh": "Cancel refresh",

--- a/translations/ui-lists/ru.json
+++ b/translations/ui-lists/ru.json
@@ -31,7 +31,6 @@
     "list.info.source": "Источник",
     "list.info.source.system": "Система",
     "accordion.title.list-information": "List information",
-    "accordion.title.query": "Query: {query}",
     "pane.dropdown.show-columns": "Show columns",
     "pane.dropdown.refresh": "Refresh list",
     "pane.dropdown.cancel-refresh": "Cancel refresh",

--- a/translations/ui-lists/sk.json
+++ b/translations/ui-lists/sk.json
@@ -31,7 +31,6 @@
     "list.info.source": "Source",
     "list.info.source.system": "System",
     "accordion.title.list-information": "List information",
-    "accordion.title.query": "Query: {query}",
     "pane.dropdown.show-columns": "Show columns",
     "pane.dropdown.refresh": "Refresh list",
     "pane.dropdown.cancel-refresh": "Cancel refresh",

--- a/translations/ui-lists/sv.json
+++ b/translations/ui-lists/sv.json
@@ -31,7 +31,6 @@
     "list.info.source": "Källa",
     "list.info.source.system": "System",
     "accordion.title.list-information": "List information",
-    "accordion.title.query": "Query: {query}",
     "pane.dropdown.show-columns": "Show columns",
     "pane.dropdown.refresh": "Refresh list",
     "pane.dropdown.cancel-refresh": "Cancel refresh",

--- a/translations/ui-lists/uk.json
+++ b/translations/ui-lists/uk.json
@@ -31,7 +31,6 @@
     "list.info.source": "Source",
     "list.info.source.system": "System",
     "accordion.title.list-information": "List information",
-    "accordion.title.query": "Query: {query}",
     "pane.dropdown.show-columns": "Show columns",
     "pane.dropdown.refresh": "Refresh list",
     "pane.dropdown.cancel-refresh": "Cancel refresh",

--- a/translations/ui-lists/ur.json
+++ b/translations/ui-lists/ur.json
@@ -31,7 +31,6 @@
     "list.info.source": "Source",
     "list.info.source.system": "System",
     "accordion.title.list-information": "List information",
-    "accordion.title.query": "Query: {query}",
     "pane.dropdown.show-columns": "Show columns",
     "pane.dropdown.refresh": "Refresh list",
     "pane.dropdown.cancel-refresh": "Cancel refresh",

--- a/translations/ui-lists/zu.json
+++ b/translations/ui-lists/zu.json
@@ -31,7 +31,6 @@
     "list.info.source": "Source",
     "list.info.source.system": "System",
     "accordion.title.list-information": "List information",
-    "accordion.title.query": "Query: {query}",
     "pane.dropdown.show-columns": "Show columns",
     "pane.dropdown.refresh": "Refresh list",
     "pane.dropdown.cancel-refresh": "Cancel refresh",


### PR DESCRIPTION
Two "real" changes here:
1. changing prop `accordionHeadline` to `showQueryAccordion` to leverage the newly exposed query display in https://github.com/folio-org/ui-plugin-query-builder/pull/238
2. consolidating some reused logic for API calling methods for the QB into their own file