### PR TITLE
[UIPQB-237] Support improved organization handling in QB

### DIFF
--- a/src/hooks/useQueryBuilderSources/useQueryBuilderSources.ts
+++ b/src/hooks/useQueryBuilderSources/useQueryBuilderSources.ts
@@ -51,15 +51,26 @@ export function useQueryBuilderCommonSources(entityTypeId: string | undefined) {
     ),
 
     getParamsSource: useCallback(
-      (p: { entityTypeId: string; columnName: string; searchValue: string }) => {
-        return ky
-          .get(`entity-types/${p.entityTypeId}/columns/${p.columnName}/values`, {
-            searchParams: {
-              search: p.searchValue,
-            },
-          })
-          .json();
-      },
+      (p: { entityTypeId: string; columnName: string; searchValue: string }) => ky
+        .get(`entity-types/${p.entityTypeId}/columns/${p.columnName}/values`, {
+          searchParams: {
+            search: p.searchValue,
+          },
+        })
+        .json(),
+      [ky],
+    ),
+
+    getOrganizations: useCallback(
+      (ids: string[], property: 'code' | 'name') => ky
+        .get('organizations/organizations', {
+          searchParams: {
+            query: ids.map((id) => `id=="${id}"`).join(' or '),
+            limit: ids.length,
+          },
+        })
+        .json<{ organizations: { id: string; code: string; name: string }[] }>()
+        .then((response) => response.organizations.map((org) => ({ value: org.id, label: org[property] }))),
       [ky],
     ),
   };


### PR DESCRIPTION
# [Jira UIPQB-237](https://folio-org.atlassian.net/browse/UIPQB-237)

## Purpose
FQM's ability to provide column values is limited for organization names and code when the env has over 1000 organizations, as discovered [here](https://folio-org.atlassian.net/browse/UIPQB-204). To resolve this, we use the organization plugin to allow the user to search for organizations directly, however, several places where queries are displayed still relied on FQM's column values for organization names/codes, causing some names/codes to not load if outside the 1000 organization limit.

## Approach
Now, the QB will fetch organization names/codes intelligently, however, it needs to make new API calls for this action. As with all others in the QB, the embedding module must pass along a function to make these calls; this PR adds the requisite new `getOrganizations` prop for bulk edit.

> [!NOTE]
> 
> This does add an API call to `mod-organizations` which is not backed by a corresponding `package.json` change to declare the API dependency. However, FQM itself requires that `mod-organizations` be present with the requisite interface version (and checks permissions), so this code would only be executed iff FQM is satisfied with `organizations` being installed. Is this sufficient, or should we add a dependency here, too?