### PR TITLE
UILISTS-226 Update permission sets to not use the mod-configuration permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change history for ui-lists
 
+## (IN PROGRESS)
+
+* Update permission sets to not use the `mod-configuration` permissions. [UILISTS-226]
+
+[UILISTS-226]: https://folio-org.atlassian.net/browse/UILISTS-226
+
 ## [4.0.3](https://github.com/folio-org/ui-lists/tree/v4.0.3) (2025-04-18)
 
 * Use query builder's user-friendly queries instead of relying on the backend. [UILISTS-223]

--- a/package.json
+++ b/package.json
@@ -122,8 +122,7 @@
           "lists.collection.get",
           "lists.item.get",
           "lists.item.contents.get",
-          "lists.configuration.get",
-          "configuration.entries.collection.get"
+          "lists.configuration.get"
         ]
       },
       {


### PR DESCRIPTION
## Purpose
https://folio-org.atlassian.net/browse/UILISTS-226

According to the `mod-configuration` decommission and the absence of usage of this interface (`configuration`), the permission is redundant and should be removed.
