### PR TITLE
Fix useRef call with noargs

### DIFF
--- a/src/components/ListsTable/ListsTable.tsx
+++ b/src/components/ListsTable/ListsTable.tsx
@@ -27,10 +27,10 @@ export const ListsTable: FC<ListsTableProps> = ({
   } = useListsPagination({});
   const { updatedListsData, setRecordIds } = useListsIdsToTrack();
 
-  const prevActiveFilters: string[] | undefined = usePrevious(activeFilters);
+  const prevActiveFilters: string[] | null = usePrevious(activeFilters);
 
   useEffect(() => {
-    if (prevActiveFilters === undefined) return;
+    if (prevActiveFilters === null) return;
 
     if (prevActiveFilters && !isEqual(prevActiveFilters, activeFilters)) {
       gotToFirstPage();

--- a/src/hooks/usePrevious/usePrevious.test.ts
+++ b/src/hooks/usePrevious/usePrevious.test.ts
@@ -5,8 +5,8 @@ describe('usePrevious', () => {
   describe('When initial render happened', () => {
     const { result } = renderHook(() => usePrevious(1));
 
-    it('is expected to return undefined', () => {
-      expect(result.current).toBeUndefined();
+    it('is expected to return null', () => {
+      expect(result.current).toBeNull();
     });
   });
 

--- a/src/hooks/usePrevious/usePrevious.ts
+++ b/src/hooks/usePrevious/usePrevious.ts
@@ -1,10 +1,10 @@
 import { useEffect, useRef } from 'react';
 
-export const usePrevious = (value: any) => {
-  const ref = useRef();
+export function usePrevious<T>(value: T): T | null {
+  const ref = useRef<T | null>(null);
   useEffect(() => {
     ref.current = value;
   });
 
   return ref.current;
-};
+}


### PR DESCRIPTION
Failures were occurring [in platform-complete builds](https://jenkins-aws.indexdata.com/blue/organizations/jenkins/folio-org%2Fplatform-complete/detail/FOLIO-4324-Edge-Consortia/1/pipeline) due to our use of a noarg call to `useRef()`.