### PR TITLE
Restore FQM interface versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 **API CHANGES:**
 * Support `lists` interface version `2.0`
-* Support `fqm-query` and `entity-types` interface versions `3.0`
+* ~~Support `fqm-query` and `entity-types` interface versions `3.0`~~ _These will not be used in Trillium_
 
 **Other changes:**
 * Update permission sets to not use the `mod-configuration` permissions. [UILISTS-226]

--- a/package.json
+++ b/package.json
@@ -103,8 +103,8 @@
     "hasSettings": false,
     "okapiInterfaces": {
       "lists": "1.0 2.0",
-      "fqm-query": "2.0 3.0",
-      "entity-types": "2.0 3.0"
+      "fqm-query": "2.0",
+      "entity-types": "2.0"
     },
     "stripesDeps": [
       "@folio/stripes-acq-components"


### PR DESCRIPTION
We won't actually be using 3.0 for trillium