### PR TITLE
UILISTS-273 BREAKING always navigate to unguardable routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Add search box to Search & filter pane [UILISTS-252]
 * Add filter by List Creator and Updated by [UILISTS-253]
+* *BREAKING* Always navigate to unguardable routes. [UILISTS-273]
 
 ## [5.0.2](https://github.com/folio-org/ui-lists/tree/v5.0.2) (2026-05-04)
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-react": "^7.9.0",
     "@folio/eslint-config-stripes": "^8.0.0",
-    "@folio/stripes": "^10.0.0",
+    "@folio/stripes": "^10.1.0",
     "@folio/stripes-cli": "^4.0.0",
     "@folio/stripes-testing": "^5.0.0",
     "@formatjs/cli": "^6.6.0",
@@ -85,7 +85,7 @@
     "prop-types": "^15.6.0"
   },
   "peerDependencies": {
-    "@folio/stripes": "^10.0.0",
+    "@folio/stripes": "^10.1.0",
     "react": "^18.2.0",
     "react-intl": "^7.1.5",
     "react-redux": "^8.0.5",

--- a/src/hooks/useNavigationBlock/useNavigationBlock.ts
+++ b/src/hooks/useNavigationBlock/useNavigationBlock.ts
@@ -5,6 +5,8 @@ import {
 } from 'react';
 import { useHistory } from 'react-router-dom';
 
+import { isGuardable } from '@folio/stripes/core';
+
 export const useNavigationBlock = (
   showModalOnCancel: boolean,
   isSaving = false,
@@ -40,8 +42,17 @@ export const useNavigationBlock = (
     }
 
     if (showModalOnCancel && !isBlocked) {
+      // the function passed to history.block() should return true if navigation
+      // should continue, false to halt navigation and stay at the present
+      // location.
+
       // @ts-ignore
       unblock = history.block((next) => {
+        // some nav (e.g. to `/logout` when a session ends) cannot be guarded
+        if (!isGuardable(next.pathname)) {
+          return true;
+        }
+
         const isListPath = /^\/lists\/list\/[0-9a-fA-F-]+$/.test(next.pathname);
 
         if (isListPath && !blockListPath) {


### PR DESCRIPTION
Sometimes, navigation cannot be guarded (as when navigating to `/logout` when a session times out). Call `stripes-core::isGuardable()` to determine whether the route may be guarded or if navigation is obligatory.

Do not show a "Stay here?" prompt for those obligatory routes.

Refs [UILISTS-273](https://folio-org.atlassian.net/browse/UILISTS-273), [STRIPES-1026](https://folio-org.atlassian.net/browse/STRIPES-1026)